### PR TITLE
fix: replace grace hibernation with warm pool and wake queue

### DIFF
--- a/src/ui/canvas/lifecycle.test.ts
+++ b/src/ui/canvas/lifecycle.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, it } from "vitest";
+import type { Camera, ProjectedFrame } from "../api";
+import type { FrameState, SweepInput } from "./lifecycle";
+import { createLifecycleModel, MOUNTS_PER_SWEEP, noteExitCapture, sweepLifecycle, WARM_POOL_CAP } from "./lifecycle";
+
+/**
+ * The lifecycle decision function (#40): fabricated frames and camera in,
+ * per-sweep states out — no browser, no real timers. The fixed stage is a
+ * 1000×1000 viewport with the camera at origin and k=1, so the strict view
+ * is world (0,0)–(1000,1000), the margin ring reaches 500 beyond every edge,
+ * and the viewport center sits at world (500,500).
+ */
+
+const SWEEP_MS = 300;
+
+const frame = (name: string, x: number, y: number, kind: "html" | "term" = "html"): ProjectedFrame => ({
+	name,
+	kind,
+	x,
+	y,
+	w: 100,
+	h: 100,
+	hasThumb: true,
+});
+
+const origin: Camera = { x: 0, y: 0, k: 1 };
+
+/** The camera panned (k=1) so the frame sits centered in the viewport. */
+const over = (f: ProjectedFrame): Camera => ({ k: 1, x: 500 - f.x - f.w / 2, y: 500 - f.y - f.h / 2 });
+
+/** Threads states and a fake clock through consecutive sweeps of one model. */
+function sweeper() {
+	const model = createLifecycleModel();
+	let now = 0;
+	let states: Record<string, FrameState> = {};
+	const sweep = (frames: ProjectedFrame[], input: Partial<Omit<SweepInput, "frames">> = {}) => {
+		now += SWEEP_MS;
+		const result = sweepLifecycle(model, {
+			frames,
+			camera: origin,
+			viewportWidth: 1000,
+			viewportHeight: 1000,
+			mode: "live",
+			entered: null,
+			selected: null,
+			states,
+			ready: new Set(frames.map((f) => f.name)),
+			capturing: new Set(),
+			hasThumb: () => true,
+			now,
+			...input,
+		});
+		states = result.states;
+		return result;
+	};
+	return { sweep, model, states: () => states };
+}
+
+/** One frame per 2000 world units: the camera parked over one sees only it. */
+const strip = (count: number, kind: "html" | "term" = "html") =>
+	Array.from({ length: count }, (_, i) => frame(`f${i}`, i * 2000, 0, kind));
+
+/** Mounts each frame in turn, giving strictly ascending last-usable times. */
+const tour = (s: ReturnType<typeof sweeper>, frames: ProjectedFrame[]) => {
+	for (const f of frames) s.sweep(frames, { camera: over(f) });
+};
+
+const parked: Camera = { x: -10_000_000, y: 0, k: 1 };
+
+describe("wake queue", () => {
+	it("drains a page entry a few mounts per sweep, nearest the viewport center first", () => {
+		// five hibernated frames strictly in view, listed out of distance order;
+		// centers sit 0/100/150/200/300 from the viewport center
+		const frames = [
+			frame("d", 250, 450),
+			frame("a", 450, 450),
+			frame("e", 450, 150),
+			frame("b", 350, 450),
+			frame("c", 450, 300),
+		];
+		const { sweep } = sweeper();
+
+		const first = sweep(frames);
+		expect(first.states).toEqual({ a: "live", b: "live", c: "live", d: "hibernated", e: "hibernated" });
+		expect(MOUNTS_PER_SWEEP).toBe(3);
+
+		const second = sweep(frames);
+		expect(second.states).toEqual({ a: "live", b: "live", c: "live", d: "live", e: "live" });
+	});
+
+	it("admits every strictly-visible frame before the margin ring, however near the ring frame sits", () => {
+		// ring frames end nearer the center in world distance (551, 650) than
+		// the strict pair parked in the far corners (602, 636)
+		const frames = [
+			frame("ring-near", -101, 450),
+			frame("ring-far", -200, 450),
+			frame("corner-a", 900, 900),
+			frame("corner-b", 900, 50),
+		];
+		const { sweep } = sweeper();
+
+		const first = sweep(frames);
+		expect(first.states).toEqual({
+			"ring-near": "live",
+			"ring-far": "hibernated",
+			"corner-a": "live",
+			"corner-b": "live",
+		});
+
+		const second = sweep(frames);
+		expect(second.states["ring-far"]).toBe("live");
+	});
+});
+
+describe("intent", () => {
+	const inView = [
+		frame("d", 250, 450),
+		frame("a", 450, 450),
+		frame("e", 450, 150),
+		frame("b", 350, 450),
+		frame("c", 450, 300),
+	];
+
+	it("mounts the entered frame in its own sweep regardless of queue depth, and keeps it live offscreen", () => {
+		const { sweep } = sweeper();
+
+		// e sits farthest from the center, yet enters alongside a full queue
+		const first = sweep(inView, { entered: "e" });
+		expect(first.states).toEqual({ a: "live", b: "live", c: "live", d: "hibernated", e: "live" });
+
+		// entered survives leaving the view
+		const away = sweep(inView, { entered: "e", camera: { x: -10000, y: 0, k: 1 } });
+		expect(away.states.e).toBe("live");
+	});
+
+	it("admits the selected frame ahead of every non-intent frame", () => {
+		const { sweep } = sweeper();
+
+		const first = sweep(inView, { selected: "e" });
+		expect(first.states).toEqual({ a: "live", b: "live", c: "hibernated", d: "hibernated", e: "live" });
+	});
+
+	it("pre-boots an offscreen selected frame to warm, still through the queue", () => {
+		const { sweep } = sweeper();
+
+		const first = sweep([frame("off", 5000, 5000)], { selected: "off" });
+		expect(first.states).toEqual({ off: "warm" });
+	});
+});
+
+describe("warm pool", () => {
+	it("a zoom round trip within capacity only freezes and unfreezes — no hibernation, ever", () => {
+		const frames = [
+			frame("a", 450, 450),
+			frame("b", 350, 450),
+			frame("c", 450, 300),
+			frame("d", 250, 450),
+			frame("e", 450, 150),
+		];
+		const { sweep } = sweeper();
+		sweep(frames);
+		sweep(frames);
+
+		// zoom far below the live threshold: everything freezes in place
+		const zoomedOut: Camera = { x: 450, y: 450, k: 0.1 };
+		const frozen = sweep(frames, { camera: zoomedOut });
+		expect(Object.values(frozen.states)).toEqual(["warm", "warm", "warm", "warm", "warm"]);
+
+		// hold for 6 s — far past the retired grace window — and nothing hibernates
+		for (let i = 0; i < 20; i++) {
+			const later = sweep(frames, { camera: zoomedOut });
+			expect(Object.values(later.states)).toEqual(["warm", "warm", "warm", "warm", "warm"]);
+		}
+
+		// zooming back unfreezes every frame in one sweep — no queue, no remount
+		const back = sweep(frames);
+		expect(Object.values(back.states)).toEqual(["live", "live", "live", "live", "live"]);
+	});
+
+	it("overflow evicts the oldest-seen html frame; its goodbye landing unmounts it", () => {
+		const frames = strip(WARM_POOL_CAP + 1);
+		const s = sweeper();
+		tour(s, frames);
+
+		// leaving the strip strands 25 offscreen warm frames — one over the cap
+		const evict = s.sweep(frames, { camera: parked });
+		expect(evict.exitCaptures).toEqual(["f0"]);
+		expect(evict.states.f0).toBe("warm");
+
+		noteExitCapture(s.model, "f0", true);
+		const landed = s.sweep(frames, { camera: parked });
+		expect(landed.states.f0).toBe("hibernated");
+
+		// the pool sits at the cap now — nothing else ever hibernates
+		expect(landed.exitCaptures).toEqual([]);
+		const rest = Object.entries(landed.states).filter(([name]) => name !== "f0");
+		expect(rest.every(([, state]) => state === "warm")).toBe(true);
+	});
+
+	it("a goodbye that never lands rides out the timeout, then unmounts", () => {
+		const frames = strip(WARM_POOL_CAP + 1);
+		const s = sweeper();
+		tour(s, frames);
+
+		const evict = s.sweep(frames, { camera: parked });
+		expect(evict.exitCaptures).toEqual(["f0"]);
+
+		// 300 ms in: still inside the 600 ms goodbye window
+		const waiting = s.sweep(frames, { camera: parked });
+		expect(waiting.states.f0).toBe("warm");
+
+		// 600 ms in: the window closes without a shot
+		const timedOut = s.sweep(frames, { camera: parked });
+		expect(timedOut.states.f0).toBe("hibernated");
+	});
+
+	it("never evicts the selected frame — pre-boot intent shields it until deselection", () => {
+		const frames = strip(WARM_POOL_CAP + 1);
+		const s = sweeper();
+		tour(s, frames);
+
+		// f0 is the oldest-seen, but selection shields it and the pool holds
+		const held = s.sweep(frames, { camera: parked, selected: "f0" });
+		expect(held.exitCaptures).toEqual([]);
+		expect(held.states.f0).toBe("warm");
+
+		// deselection releases it to normal pool policy
+		const released = s.sweep(frames, { camera: parked });
+		expect(released.exitCaptures).toEqual(["f0"]);
+	});
+
+	it("rescues an eviction mid-goodbye when its frame comes back into view", () => {
+		const frames = strip(WARM_POOL_CAP + 1);
+		const s = sweeper();
+		tour(s, frames);
+
+		const evict = s.sweep(frames, { camera: parked });
+		expect(evict.exitCaptures).toEqual(["f0"]);
+
+		// the camera returns to f0 before its goodbye resolves
+		const rescued = s.sweep(frames, { camera: over(frame("f0", 0, 0)) });
+		expect(rescued.states.f0).toBe("live");
+		expect(rescued.exitCaptures).toEqual([]);
+
+		// leaving again, past the old goodbye window: f0 is now the newest-seen
+		// and stays warm — the pool evicts f1, the oldest, instead
+		const leave = s.sweep(frames, { camera: parked });
+		expect(leave.states.f0).toBe("warm");
+		expect(leave.states.f1).toBe("warm");
+		expect(leave.exitCaptures).toEqual(["f1"]);
+	});
+
+	it("evicts a terminal frame without requesting a goodbye capture", () => {
+		const frames = strip(WARM_POOL_CAP + 1, "term");
+		const s = sweeper();
+		tour(s, frames);
+
+		const evict = s.sweep(frames, { camera: parked });
+		expect(evict.exitCaptures).toEqual([]);
+		expect(evict.states.f0).toBe("hibernated");
+		expect(evict.states.f1).toBe("warm");
+	});
+});
+
+describe("thumbnail refresh", () => {
+	it("a frame leaving live refreshes its still once the camera settles", () => {
+		const frames = [frame("a", 450, 450)];
+		const s = sweeper();
+		s.sweep(frames);
+
+		// leaving live stales the still, but the camera just moved — no shot yet
+		const left = s.sweep(frames, { camera: parked });
+		expect(left.states.a).toBe("warm");
+		expect(left.refreshCaptures).toEqual([]);
+
+		// 300 ms after the move: still inside the 400 ms settle window
+		expect(s.sweep(frames, { camera: parked }).refreshCaptures).toEqual([]);
+
+		// settled: the refresh fires once, then the debt is paid
+		expect(s.sweep(frames, { camera: parked }).refreshCaptures).toEqual(["a"]);
+		expect(s.sweep(frames, { camera: parked }).refreshCaptures).toEqual([]);
+	});
+
+	it("a missing still backfills when settled, unless a capture is already in flight", () => {
+		const frames = [frame("a", 450, 450)];
+		const s = sweeper();
+		const hasThumb = () => false;
+		s.sweep(frames, { hasThumb });
+		expect(s.sweep(frames, { hasThumb }).refreshCaptures).toEqual([]);
+
+		// settled and thumbless — but an in-flight capture holds the debt open
+		expect(s.sweep(frames, { hasThumb, capturing: new Set(["a"]) }).refreshCaptures).toEqual([]);
+		expect(s.sweep(frames, { hasThumb }).refreshCaptures).toEqual(["a"]);
+	});
+});
+
+describe("design mode", () => {
+	it("a design flip drains every hibernated frame through the queue, on- and offscreen", () => {
+		const frames = [
+			frame("a", 450, 450),
+			frame("b", 350, 450),
+			frame("c", 450, 300),
+			frame("d", 250, 450),
+			frame("e", 3000, 450),
+			frame("f", 4000, 450),
+			frame("g", 5000, 450),
+			frame("h", 6000, 450),
+		];
+		const { sweep } = sweeper();
+
+		const first = sweep(frames, { mode: "design" });
+		expect(first.states).toEqual({
+			a: "warm",
+			b: "warm",
+			c: "warm",
+			d: "hibernated",
+			e: "hibernated",
+			f: "hibernated",
+			g: "hibernated",
+			h: "hibernated",
+		});
+
+		const second = sweep(frames, { mode: "design" });
+		expect(second.states.d).toBe("warm");
+		expect(second.states.e).toBe("warm");
+		expect(second.states.f).toBe("warm");
+		expect(second.states.g).toBe("hibernated");
+
+		const third = sweep(frames, { mode: "design" });
+		expect(Object.values(third.states).every((state) => state === "warm")).toBe(true);
+	});
+
+	it("admits the margin ring before fully offscreen frames, whatever their distances", () => {
+		// the ring frame sits farther from the center (≈1273) than every
+		// offscreen frame (1150, 1200, 1250) — the tier must still win
+		const frames = [
+			frame("r1", 1600, 450),
+			frame("r2", 1650, 450),
+			frame("r3", 1700, 450),
+			frame("ring", -450, -450),
+		];
+		const { sweep } = sweeper();
+
+		const first = sweep(frames, { mode: "design" });
+		expect(first.states).toEqual({ ring: "warm", r1: "warm", r2: "warm", r3: "hibernated" });
+	});
+
+	it("never evicts in design mode; returning to live evicts back down to the cap", () => {
+		const frames = strip(WARM_POOL_CAP + 3);
+		const s = sweeper();
+
+		// nine design sweeps mount all 27 frames, three per sweep, no evictions
+		for (let i = 0; i < 9; i++) {
+			const result = s.sweep(frames, { mode: "design", camera: parked });
+			expect(result.exitCaptures).toEqual([]);
+			expect(Object.values(result.states).filter((state) => state === "hibernated")).toHaveLength(27 - 3 * (i + 1));
+		}
+
+		// back to live: three over the cap, never seen usable — frames-order ties
+		const back = s.sweep(frames, { camera: parked });
+		expect(back.exitCaptures).toEqual(["f0", "f1", "f2"]);
+	});
+
+	it("a design flip rescues an eviction mid-goodbye; leaving design restarts it cleanly", () => {
+		const frames = strip(WARM_POOL_CAP + 1);
+		const s = sweeper();
+		tour(s, frames);
+
+		const evict = s.sweep(frames, { camera: parked });
+		expect(evict.exitCaptures).toEqual(["f0"]);
+
+		// the flip cancels the goodbye — real DOM everywhere, nothing unmounts
+		const design = s.sweep(frames, { mode: "design", camera: parked });
+		expect(Object.values(design.states).every((state) => state === "warm")).toBe(true);
+
+		// back to live past the old goodbye window: a stale exit would hibernate
+		// f0 silently; a clean pool evicts it afresh, goodbye and all
+		const back = s.sweep(frames, { camera: parked });
+		expect(back.exitCaptures).toEqual(["f0"]);
+		expect(back.states.f0).toBe("warm");
+	});
+});

--- a/src/ui/canvas/lifecycle.ts
+++ b/src/ui/canvas/lifecycle.ts
@@ -1,28 +1,234 @@
 import type { RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Camera, CanvasMode, ProjectedFrame } from "../api";
-import { intersects, visibleWorldRect } from "./camera";
+import { intersects, toWorld, visibleWorldRect } from "./camera";
 import { captureMessage } from "./protocol";
 
 /**
- * The engine lifecycle (#8, #13): which frames run, which stand frozen, which
- * exist only as their thumbnail. Live mode: near frames play; tiny-rendered
+ * The engine lifecycle (#8, #13, #40): which frames run, which stand frozen,
+ * which exist only as their still. Live mode: near frames play; tiny-rendered
  * and offscreen frames freeze (Chrome free-runs tiny live frames at 500+ Hz —
- * the zoom threshold is load-bearing), and after a grace window they take a
- * goodbye self-capture and unmount. Design mode: real DOM everywhere, time
- * stopped. Hibernation is automatic engine lifecycle, never a user mode;
- * double-click boots a hibernated frame fresh — reset-on-return is a feature.
+ * the zoom threshold is load-bearing) and stay mounted in the warm pool.
+ * Hibernation's payoff is memory, never CPU: only pool overflow demotes a
+ * frame to its still, oldest-seen first, html frames taking a goodbye
+ * self-capture on the way out. Every mount drains through the wake queue —
+ * entered immediately, selected next, then nearest the viewport center, a
+ * few per sweep — so no burst site (zoom wake, design flip, page entry) can
+ * land every mount in one commit. Design mode: real DOM everywhere, time
+ * stopped, never evicted. Hibernation is automatic engine lifecycle, never a
+ * user mode; double-click boots a hibernated frame fresh — reset-on-return
+ * is a feature.
  */
 
 export type FrameState = "live" | "warm" | "hibernated";
 
 const MARGIN_FRACTION = 0.5; // extra viewport fractions kept mounted around the screen
 const K_MIN_LIVE = 0.15; // below this zoom nothing is interactable anyway
-const GRACE_MS = 2000; // offscreen time a frame stays warm before hibernating
-const EXIT_CAPTURE_TIMEOUT_MS = 600; // how long hibernation waits for the goodbye shot
+const EXIT_CAPTURE_TIMEOUT_MS = 600; // how long an eviction waits for the goodbye shot
 const CAMERA_SETTLE_MS = 400; // capture on settle, never mid-gesture
 const SWEEP_MS = 300;
 const CAPTURE_REPLY_TIMEOUT_MS = 3000;
+export const MOUNTS_PER_SWEEP = 3; // wake-queue drain rate: 3 × ~8 ms ≈ one skipped paint per sweep at worst
+export const WARM_POOL_CAP = 24; // offscreen warm frames kept mounted; each holds ~4.6 MB and a renderer
+
+/** The decision function's persistent bookkeeping, owned by the hook, fabricated by tests. */
+export interface LifecycleModel {
+	/** When each frame was last usable — the warm pool evicts oldest-seen first. */
+	lastUsable: Map<string, number>;
+	/** Evictions mid-goodbye: the frame stays warm until its capture lands or times out. */
+	exitPending: Map<string, { t0: number; captured: boolean }>;
+	/** Frames whose still went stale — a source edit, or leaving live. */
+	staleStills: Set<string>;
+	prevCamera: Camera | null;
+	lastCameraMove: number;
+}
+
+export function createLifecycleModel(): LifecycleModel {
+	return {
+		lastUsable: new Map(),
+		exitPending: new Map(),
+		staleStills: new Set(),
+		prevCamera: null,
+		lastCameraMove: 0,
+	};
+}
+
+/** The goodbye shot's outcome — an eviction mid-dance learns whether its capture landed. */
+export function noteExitCapture(model: LifecycleModel, frame: string, captured: boolean): void {
+	const exit = model.exitPending.get(frame);
+	if (exit !== undefined) exit.captured = captured;
+}
+
+export interface SweepInput {
+	frames: readonly ProjectedFrame[];
+	camera: Camera;
+	viewportWidth: number;
+	viewportHeight: number;
+	mode: CanvasMode;
+	entered: string | null;
+	selected: string | null;
+	states: Readonly<Record<string, FrameState>>;
+	/** Frames whose boot has reported loaded — the ones a capture can reach. */
+	ready: ReadonlySet<string>;
+	/** Frames with a capture already in flight. */
+	capturing: ReadonlySet<string>;
+	hasThumb: (frame: string) => boolean;
+	now: number;
+}
+
+export interface SweepResult {
+	states: Record<string, FrameState>;
+	changed: boolean;
+	/** Evicted html frames owed a goodbye capture; route each outcome to noteExitCapture. */
+	exitCaptures: string[];
+	/** Frames whose still should refresh while their DOM is mounted and settled. */
+	refreshCaptures: string[];
+}
+
+export function sweepLifecycle(model: LifecycleModel, input: SweepInput): SweepResult {
+	const {
+		frames,
+		camera,
+		viewportWidth,
+		viewportHeight,
+		mode,
+		entered,
+		selected,
+		states,
+		ready,
+		capturing,
+		hasThumb,
+		now,
+	} = input;
+
+	const prev = model.prevCamera;
+	if (prev === null || prev.x !== camera.x || prev.y !== camera.y || prev.k !== camera.k) {
+		model.prevCamera = { ...camera };
+		model.lastCameraMove = now;
+	}
+	const settled = now - model.lastCameraMove > CAMERA_SETTLE_MS;
+
+	const margined = visibleWorldRect(camera, viewportWidth, viewportHeight, MARGIN_FRACTION);
+	const strict = visibleWorldRect(camera, viewportWidth, viewportHeight, 0);
+	const center = toWorld({ x: viewportWidth / 2, y: viewportHeight / 2 }, camera);
+
+	interface Entry {
+		frame: ProjectedFrame;
+		current: FrameState;
+		usable: boolean;
+		target: FrameState;
+	}
+	const entries: Entry[] = [];
+	// the wake queue: every mount waits here; strictly-visible frames precede
+	// the margin ring, nearest the viewport center first within each tier
+	const waiting: { entry: Entry; wakeTo: "live" | "warm"; tier: number; dist: number }[] = [];
+
+	for (const frame of frames) {
+		const current = states[frame.name] ?? "hibernated";
+		const onScreen = intersects(margined, frame);
+		const usable = onScreen && camera.k >= K_MIN_LIVE;
+		if (usable) {
+			model.lastUsable.set(frame.name, now);
+			// coming back into view rescues an eviction mid-goodbye
+			model.exitPending.delete(frame.name);
+		}
+
+		let target: FrameState;
+		let wakeTo: "live" | "warm" | null = null;
+		if (mode === "design") {
+			// design: time frozen everywhere (#8), real DOM everywhere — the
+			// canvas exits any entered frame on the way into design mode
+			model.exitPending.delete(frame.name);
+			target = current === "hibernated" ? "hibernated" : "warm";
+			if (current === "hibernated") wakeTo = "warm";
+		} else if (current !== "hibernated") {
+			target = entered === frame.name || usable ? "live" : "warm";
+		} else if (entered === frame.name) {
+			// entering mounts in its own sweep, bypassing the cap
+			target = "live";
+		} else {
+			target = "hibernated";
+			// first click pre-boots (#8): a selected frame mounts hidden so the
+			// double-click that follows reveals an already-running frame
+			wakeTo = usable ? "live" : selected === frame.name ? "warm" : null;
+		}
+
+		const entry: Entry = { frame, current, usable, target };
+		entries.push(entry);
+		if (wakeTo !== null) {
+			const cx = frame.x + frame.w / 2 - center.x;
+			const cy = frame.y + frame.h / 2 - center.y;
+			const tier = selected === frame.name ? 0 : intersects(strict, frame) ? 1 : onScreen ? 2 : 3;
+			waiting.push({ entry, wakeTo, tier, dist: cx * cx + cy * cy });
+		}
+	}
+
+	waiting.sort((a, b) => a.tier - b.tier || a.dist - b.dist);
+	for (const admitted of waiting.slice(0, MOUNTS_PER_SWEEP)) admitted.entry.target = admitted.wakeTo;
+
+	const exitCaptures: string[] = [];
+	if (mode !== "design") {
+		// resolve in-flight goodbyes: the capture landed or timed out — unmount now
+		for (const entry of entries) {
+			if (entry.target !== "warm") continue;
+			const exit = model.exitPending.get(entry.frame.name);
+			if (exit === undefined) continue;
+			if (exit.captured || now - exit.t0 >= EXIT_CAPTURE_TIMEOUT_MS) {
+				model.exitPending.delete(entry.frame.name);
+				entry.target = "hibernated";
+			}
+		}
+		// the warm pool: only overflow hibernates, oldest-seen first — live frames
+		// never count, the selected frame is pre-boot intent (evicting it would
+		// only re-queue it), and a mid-goodbye frame is already on its way out
+		const pool = entries.filter(
+			(e) => e.target === "warm" && !e.usable && e.frame.name !== selected && !model.exitPending.has(e.frame.name),
+		);
+		const overflow = pool.length - WARM_POOL_CAP;
+		if (overflow > 0) {
+			pool.sort((a, b) => (model.lastUsable.get(a.frame.name) ?? 0) - (model.lastUsable.get(b.frame.name) ?? 0));
+			for (const evicted of pool.slice(0, overflow)) {
+				if (evicted.frame.kind === "term") {
+					// a terminal's still is the daemon's grid (#42) — no goodbye capture
+					evicted.target = "hibernated";
+				} else {
+					// one goodbye self-capture while the DOM still exists
+					model.exitPending.set(evicted.frame.name, { t0: now, captured: false });
+					exitCaptures.push(evicted.frame.name);
+				}
+			}
+		}
+	}
+
+	const refreshCaptures: string[] = [];
+	const next: Record<string, FrameState> = {};
+	let changed = false;
+	for (const { frame, current, target } of entries) {
+		// leaving live stales the still; refresh once the camera settles,
+		// while the (hidden) DOM is still mounted
+		if (current === "live" && target === "warm" && frame.kind !== "term") model.staleStills.add(frame.name);
+		if (
+			frame.kind !== "term" &&
+			target !== "hibernated" &&
+			settled &&
+			(model.staleStills.has(frame.name) || !hasThumb(frame.name)) &&
+			!capturing.has(frame.name) &&
+			!model.exitPending.has(frame.name) &&
+			ready.has(frame.name)
+		) {
+			model.staleStills.delete(frame.name);
+			refreshCaptures.push(frame.name);
+		}
+		next[frame.name] = target;
+		if (target !== current) changed = true;
+	}
+	return {
+		states: next,
+		changed: changed || Object.keys(states).length !== frames.length,
+		exitCaptures,
+		refreshCaptures,
+	};
+}
 
 export interface LifecycleDeps {
 	framesRef: RefObject<ProjectedFrame[]>;
@@ -56,12 +262,8 @@ export function useFrameLifecycle(deps: LifecycleDeps) {
 	onShotRef.current = onShot;
 
 	const iframes = useRef(new Map<string, HTMLIFrameElement>());
-	const lastUsable = useRef(new Map<string, number>());
-	const exitPending = useRef(new Map<string, { t0: number; captured: boolean }>());
-	const needsShot = useRef(new Set<string>());
+	const model = useRef(createLifecycleModel());
 	const captureWaiters = useRef(new Map<string, (url: string | undefined) => void>());
-	const prevCamera = useRef<Camera | null>(null);
-	const lastCameraMove = useRef(0);
 
 	const onIframe = useCallback((frame: string, el: HTMLIFrameElement | null) => {
 		if (el !== null) {
@@ -118,87 +320,25 @@ export function useFrameLifecycle(deps: LifecycleDeps) {
 		const viewport = viewportRef.current;
 		const frames = framesRef.current;
 		if (camera === null || viewport === null) return;
-		const now = performance.now();
-
-		const prev = prevCamera.current;
-		if (prev === null || prev.x !== camera.x || prev.y !== camera.y || prev.k !== camera.k) {
-			prevCamera.current = { ...camera };
-			lastCameraMove.current = now;
+		const result = sweepLifecycle(model.current, {
+			frames,
+			camera,
+			viewportWidth: viewport.clientWidth,
+			viewportHeight: viewport.clientHeight,
+			mode: modeRef.current,
+			entered: enteredRef.current,
+			selected: selectedRef.current,
+			states: statesRef.current,
+			ready: readyRef.current,
+			capturing: new Set(captureWaiters.current.keys()),
+			hasThumb: hasThumbRef.current,
+			now: performance.now(),
+		});
+		for (const frame of result.exitCaptures) {
+			void requestCapture(frame).then((url) => noteExitCapture(model.current, frame, url !== undefined));
 		}
-		const settled = now - lastCameraMove.current > CAMERA_SETTLE_MS;
-
-		const visible = visibleWorldRect(camera, viewport.clientWidth, viewport.clientHeight, MARGIN_FRACTION);
-		const next: Record<string, FrameState> = {};
-		let changed = false;
-
-		for (const frame of frames) {
-			const current = statesRef.current[frame.name] ?? "hibernated";
-			const onScreen = intersects(visible, frame);
-			const usable = onScreen && camera.k >= K_MIN_LIVE;
-			if (usable) {
-				lastUsable.current.set(frame.name, now);
-				exitPending.current.delete(frame.name);
-			}
-
-			let target: FrameState;
-			if (modeRef.current === "design") {
-				// design: time frozen everywhere (#8), no exceptions — the canvas
-				// exits any entered frame on the way into design mode
-				target = "warm";
-				exitPending.current.delete(frame.name);
-			} else if (enteredRef.current === frame.name) {
-				target = "live";
-			} else if (usable) {
-				target = "live";
-			} else if (current === "hibernated") {
-				target = "hibernated";
-			} else if (now - (lastUsable.current.get(frame.name) ?? 0) < GRACE_MS) {
-				target = "warm";
-			} else if (frame.kind === "term") {
-				// a terminal's still is the daemon's grid (#42) — no goodbye capture
-				target = "hibernated";
-			} else {
-				// past grace: try one goodbye capture while the DOM still exists
-				const exit = exitPending.current.get(frame.name);
-				if (exit === undefined) {
-					exitPending.current.set(frame.name, { t0: now, captured: false });
-					void requestCapture(frame.name).then((url) => {
-						const entry = exitPending.current.get(frame.name);
-						if (entry !== undefined) entry.captured = url !== undefined;
-					});
-					target = "warm";
-				} else if (exit.captured || now - exit.t0 >= EXIT_CAPTURE_TIMEOUT_MS) {
-					exitPending.current.delete(frame.name);
-					target = "hibernated";
-				} else {
-					target = "warm";
-				}
-			}
-
-			// first click pre-boots (#8): a selected frame mounts hidden so the
-			// double-click that follows reveals an already-running frame
-			if (target === "hibernated" && selectedRef.current === frame.name) target = "warm";
-			// leaving live stales the thumbnail; refresh once the camera settles,
-			// while the (hidden) DOM is still mounted
-			if (current === "live" && target === "warm" && frame.kind !== "term") needsShot.current.add(frame.name);
-			if (
-				frame.kind !== "term" &&
-				target !== "hibernated" &&
-				settled &&
-				(needsShot.current.has(frame.name) || !hasThumbRef.current(frame.name)) &&
-				!captureWaiters.current.has(frame.name) &&
-				!exitPending.current.has(frame.name) &&
-				readyRef.current.has(frame.name)
-			) {
-				needsShot.current.delete(frame.name);
-				void requestCapture(frame.name);
-			}
-
-			next[frame.name] = target;
-			if (target !== current) changed = true;
-		}
-
-		if (changed || Object.keys(statesRef.current).length !== frames.length) setStates(next);
+		for (const frame of result.refreshCaptures) void requestCapture(frame);
+		if (result.changed) setStates(result.states);
 	}, [cameraRef, viewportRef, framesRef, requestCapture]);
 
 	// mode flips recompute immediately — D must feel instant, not one sweep late
@@ -214,7 +354,7 @@ export function useFrameLifecycle(deps: LifecycleDeps) {
 
 	/** A source edit made this frame's cover stale (#22: SSE-live updates). */
 	const markStale = useCallback((frame: string) => {
-		needsShot.current.add(frame);
+		model.current.staleStills.add(frame);
 	}, []);
 
 	return { states, ready, onIframe, noteLoaded, noteShot, markStale, capture: requestCapture };


### PR DESCRIPTION
Closes #40.

## What

The canvas lifecycle no longer hibernates offscreen frames on a 2s grace timer, and no longer flips every woken frame in one commit. Two policies replace `GRACE_MS`, implemented inside the (now extracted, pure) decision function `sweepLifecycle`:

- **Warm pool** — offscreen frames stay warm indefinitely; only pool overflow (`WARM_POOL_CAP = 24`) hibernates, evicting the oldest-seen first. An html eviction still lands its goodbye capture; a terminal eviction requests none. Design mode never evicts; returning to live evicts back down to the cap.
- **Wake queue** — every mount drains through one queue, `MOUNTS_PER_SWEEP = 3`: the entered frame mounts in its own sweep bypassing the cap, the selected frame goes first, then strictly-visible frames nearest the viewport center, then the margin ring, then fully offscreen frames. All burst sites (zoom wake, design flip, page entry, pre-boots) ride the same discipline.

The React hook is now a thin shell: it feeds `sweepLifecycle` refs and executes its capture effects. 17 deterministic unit tests drive the decision function with fabricated frames, cameras, and a fake clock — no browser, no real timers.

## Review notes (two-axis /code-review ran; both axes clean, two judgement calls surfaced)

- **Pool membership reading**: "Live/onscreen frames never count against the pool" is implemented as *usable* frames never count — onscreen frames frozen below `K_MIN_LIVE` are pool members, which is what makes the "zoom round trip **within pool capacity**" criterion meaningful. Flagging per review in case the other reading (any onscreen frame exempt) was intended; that reading makes deep zoom-out memory unbounded.
- **Selected-frame eviction immunity**: the pool never evicts the selected frame (evicting pre-boot intent would just re-queue it). Not in the brief's eviction clause; now commented and pinned by a test.
- `CONTEXT.md`'s wake-queue entry says "then nearest the viewport center" — the implementation refines this with visibility tiers (strict > ring > offscreen) per the acceptance criteria; the glossary entry could absorb the refinement if wanted (left canon untouched).

## Gates

`pnpm typecheck`, `pnpm check`, `pnpm test` — 479/479.