### PR TITLE
fix: spell the terminal exit chord as esc

### DIFF
--- a/src/runtime/player-runtime.test.ts
+++ b/src/runtime/player-runtime.test.ts
@@ -560,7 +560,7 @@ describe("live terminal screens (#44)", () => {
 		expect(document.querySelector(".spool-term-poster svg")).not.toBeNull();
 
 		// the pill shows the one binding chrome may answer; html screens show none
-		expect(document.querySelector(".spool-term-chord")?.textContent).toContain("⎋");
+		expect(document.querySelector(".spool-term-chord")?.textContent).toContain("esc");
 	});
 
 	it("a nav the TUI fired advances the walk and verifies its edge — only from the current screen", async () => {

--- a/src/runtime/term-keys.test.ts
+++ b/src/runtime/term-keys.test.ts
@@ -35,13 +35,13 @@ describe("termKeyIntent — the parity law for keys", () => {
 
 describe("exitChordLabel — the binding as this platform spells it", () => {
 	it("spells the command chord on Apple platforms", () => {
-		expect(exitChordLabel("MacIntel")).toBe("⌘⎋");
-		expect(exitChordLabel("iPhone")).toBe("⌘⎋");
+		expect(exitChordLabel("MacIntel")).toBe("⌘esc");
+		expect(exitChordLabel("iPhone")).toBe("⌘esc");
 	});
 
 	it("spells the control chord everywhere else, unknown platforms included", () => {
-		expect(exitChordLabel("Win32")).toBe("ctrl+⎋");
-		expect(exitChordLabel("Linux x86_64")).toBe("ctrl+⎋");
-		expect(exitChordLabel("")).toBe("ctrl+⎋");
+		expect(exitChordLabel("Win32")).toBe("ctrl+esc");
+		expect(exitChordLabel("Linux x86_64")).toBe("ctrl+esc");
+		expect(exitChordLabel("")).toBe("ctrl+esc");
 	});
 });

--- a/src/runtime/term-keys.ts
+++ b/src/runtime/term-keys.ts
@@ -22,7 +22,9 @@ export function exitChipLabel(code: number): string {
 	return `exited ${code}`;
 }
 
-/** The exit chord as a given platform spells it — chrome shows a chord that works there. */
+/** The exit chord as a given platform spells it. "esc" is a word, not ⎋:
+ * the chrome fonts don't carry that glyph, and its system fallback renders
+ * as an unreadable slashed circle. */
 export function exitChordLabel(platform: string): string {
-	return /Mac|iP/.test(platform) ? "⌘⎋" : "ctrl+⎋";
+	return /Mac|iP/.test(platform) ? "⌘esc" : "ctrl+esc";
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -91,7 +91,7 @@ Everything a TUI can be, this is: OpenTUI's <box>/<text> layout, useKeyboard for
 
 Cells are the units. New terminal frames are born 80×24 — the conventional floor; design up from it. Resizing on the canvas snaps to whole cells and shows a cols×rows badge; the process receives a real terminal resize and reflows live. frame.json stays pixels (the canvas's one geometry language): one cell is 9×18px in the pinned mono (JetBrains Mono at 15px), so 80×24 = 720×432. Write w/h yourself in whole-cell multiples for an exact grid.
 
-Entered, a terminal owns the whole keyboard: Escape, Ctrl+C, Ctrl+Z — every key reaches the process, because those belong to the TUI. The one way out is the platform modifier + Escape (⌘⎋ / Ctrl⎋), shown in the chip; clicking outside always works too.
+Entered, a terminal owns the whole keyboard: Escape, Ctrl+C, Ctrl+Z — every key reaches the process, because those belong to the TUI. The one way out is the platform modifier + Escape (⌘esc / ctrl+esc), shown in the chip; clicking outside always works too.
 
 The loop is write–save–see: saving term.tsx kills and respawns the process. A process that exits — a crash or a designed q — keeps its last screen dimmed with an exit-code chip; it revives on save or on entering it, never by itself. Offscreen, spool freezes the process at the kernel (zero CPU) and eventually kills it with its screen serialized — scroll back and it wakes fresh. Cold boots are the contract: design TUIs that stand up their own state.
 


### PR DESCRIPTION
The pill's chord chip rendered ⎋ (U+238B) through a system fallback — Fragment Mono's latin subset has no glyph for it — which draws as an unreadable slashed circle. "esc" is a word every font carries and nobody misreads. Applies to the player pill, the canvas entered label (shared helper), and the skill text: ⌘esc / ctrl+esc.