### PR TITLE
feat: canvas file tree — element tree sidebar with multi-element selection

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,7 +36,7 @@ Spool is a local-first prototyping canvas: agents author live TSX frames on disk
 
 **Warm pool**: The bounded set of offscreen frames kept mounted with time frozen; overflowing it, oldest-seen first, is the only path into hibernation. _Avoid_: cache
 
-**Wake queue**: The single ordered path a frame takes into the DOM, drained a few mounts per sweep — entered immediately, selected next, then nearest the viewport center. Every burst site (zoom wake, design flip, page entry) drains through it.
+**Wake queue**: The single ordered path a frame takes into the DOM, drained a few mounts per sweep — entered immediately, selected next, then wake-requested tree rows, then nearest the viewport center. Every burst site (zoom wake, design flip, page entry, tree expand) drains through it.
 
 **Hands**: The human at the canvas. Hands own geometry and arrangement; agents own frame source. _Avoid_: user, designer
 

--- a/docs/adr/0006-warm-pool-and-wake-queue-replace-the-hibernation-timer.md
+++ b/docs/adr/0006-warm-pool-and-wake-queue-replace-the-hibernation-timer.md
@@ -5,3 +5,7 @@ The live-frames spike behind #40 overturned the assumption hibernation was built
 ## Considered options
 
 A longer grace timer keeps the burst and merely delays it. Memory-API budgets (`performance.memory`, pressure events) are Chrome-only and make lifecycle behavior machine-dependent and untestable. Cross-page warmth would mount frames the page filter deliberately excludes. Fixed counts — pool cap and mounts per sweep — are dumb, deterministic, and tunable.
+
+## Amended by #37
+
+The sidebar element tree made expand a wake intent: a frame whose tree row is open enters the queue at a tier behind selected and ahead of the visible tiers, and while the row stays open the frame is exempt from pool eviction — evicting it would drop its DOM walk and re-queue it on the next sweep, an expand/evict thrash. The queue order is now: entered immediately, selected, wake-requested rows, then nearest the viewport center.

--- a/src/daemon/app.ts
+++ b/src/daemon/app.ts
@@ -19,6 +19,7 @@ import { lookupProjectByName, readRegistry } from "../registry";
 import { cellsForPx } from "../term/cells";
 import { type Grid, gridToSvg } from "../term/still";
 import { requestUpgrade } from "../upgrade";
+import { stampLabels } from "./call-site";
 import { createFrameCompiler } from "./compile";
 import { errorDocument } from "./document";
 import { createChangeHub } from "./events";
@@ -492,6 +493,27 @@ export function createDaemonApp({
 				// the whole folder moves; the OS Trash owns restore from here (#7)
 				await trashImpl(dirs);
 				return c.body(null, 204);
+			},
+		)
+		.post(
+			"/api/p/:project/stamp-labels",
+			validator("json", (value, c) => {
+				const stamps =
+					typeof value === "object" && value !== null ? (value as { stamps?: unknown }).stamps : undefined;
+				if (
+					!Array.isArray(stamps) ||
+					stamps.length > 256 ||
+					!stamps.every((stamp): stamp is string => typeof stamp === "string")
+				) {
+					return c.text('stamp-labels must be { "stamps": ["frames/…:line:col", ...] }, at most 256', 400);
+				}
+				return { stamps };
+			}),
+			(c) => {
+				// the tree's call-site rows (#37): each stamp's repeating call, or null
+				const project = resolveProject(c, c.req.param("project"));
+				if ("response" in project) return project.response;
+				return c.json({ labels: stampLabels(project.root, c.req.valid("json").stamps) });
 			},
 		)
 		.post(

--- a/src/daemon/call-site.test.ts
+++ b/src/daemon/call-site.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { callSiteLabel } from "./call-site";
+
+/**
+ * The call-site label (#37): siblings sharing a stamp collapse into one row,
+ * and the row's name is the call that repeats them — read straight out of the
+ * stamped source, never guessed from the DOM.
+ */
+
+describe("callSiteLabel", () => {
+	it("names a multiline map call from the stamped element", () => {
+		const source = [
+			"export default function Cart() {",
+			"\treturn (",
+			"\t\t<div>",
+			"\t\t\t{cart.map((item) => (",
+			'\t\t\t\t<div className="row">{item.name}</div>',
+			"\t\t\t))}",
+			"\t\t</div>",
+			"\t);",
+			"}",
+		].join("\n");
+
+		expect(callSiteLabel(source, 5, 5)).toBe("cart.map(…)");
+	});
+
+	it("names an inline map with unparenthesized arrow params", () => {
+		const source = "const List = () => <ul>{items.map(item => <li key={item}>{item}</li>)}</ul>;\n";
+
+		expect(callSiteLabel(source, 1, 43)).toBe("items.map(…)");
+	});
+
+	it("keeps the whole property chain", () => {
+		const source = ["<div>", "\t{data.rows.flatMap((row) => (", "\t\t<span>{row}</span>", "\t))}", "</div>"].join(
+			"\n",
+		);
+
+		expect(callSiteLabel(source, 3, 3)).toBe("data.rows.flatMap(…)");
+	});
+
+	it("answers nothing for an element outside any call", () => {
+		const source = ["<main>", '\t<div className="row">x</div>', "</main>"].join("\n");
+
+		expect(callSiteLabel(source, 2, 2)).toBeUndefined();
+	});
+
+	it("answers nothing when the stamp no longer lands on an element", () => {
+		const source = "const x = 1;\n";
+
+		expect(callSiteLabel(source, 1, 1)).toBeUndefined();
+	});
+});

--- a/src/daemon/call-site.ts
+++ b/src/daemon/call-site.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { offsetOf } from "./jsx-span";
+import { parseStamp } from "./selection";
+
+/**
+ * The call-site label (#37): DOM siblings sharing one stamp collapse into a
+ * single tree row, named after the call that repeats them — `cart.map(…)`.
+ * The name is read from the stamped source: the nearest call chain whose
+ * argument is the arrow (or parenthesized arrow body) the element opens.
+ * Anything else — an element outside a call, a stamp the file outgrew —
+ * answers undefined; the row then stands on its tag and count alone.
+ */
+
+const WINDOW = 240;
+
+/** `ident(.prop)*(` followed only by an arrow preamble up to the element. */
+const CALL_OPEN = /([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(/g;
+const ARROW_PREAMBLE = /^\s*(?:\([^()]*\)|[A-Za-z_$][\w$]*)\s*=>\s*\(?\s*$/;
+
+export function callSiteLabel(source: string, line: number, column: number): string | undefined {
+	const start = offsetOf(source, line, column);
+	if (start === undefined || source[start] !== "<") return undefined;
+
+	const windowStart = Math.max(0, start - WINDOW);
+	const window = source.slice(windowStart, start);
+	let found: string | undefined;
+	CALL_OPEN.lastIndex = 0;
+	for (let match = CALL_OPEN.exec(window); match !== null; match = CALL_OPEN.exec(window)) {
+		const chain = match[1];
+		if (chain === undefined) continue;
+		const between = window.slice(match.index + match[0].length);
+		// the nearest qualifying call wins — keep scanning to the window's end
+		if (ARROW_PREAMBLE.test(between)) found = `${chain}(…)`;
+	}
+	return found;
+}
+
+/** Each stamp's call-site label — null where there is no call, file, or stamp. */
+export function stampLabels(root: string, stamps: readonly string[]): Record<string, string | null> {
+	const files = new Map<string, string | undefined>();
+	const labels: Record<string, string | null> = {};
+	for (const source of stamps) {
+		labels[source] = null;
+		const stamp = parseStamp(root, source);
+		if (stamp === undefined) continue;
+		if (!files.has(stamp.file)) {
+			try {
+				files.set(stamp.file, readFileSync(stamp.file, "utf8"));
+			} catch {
+				files.set(stamp.file, undefined);
+			}
+		}
+		const text = files.get(stamp.file);
+		if (text === undefined) continue;
+		labels[source] = callSiteLabel(text, stamp.line, stamp.column) ?? null;
+	}
+	return labels;
+}

--- a/src/daemon/document.ts
+++ b/src/daemon/document.ts
@@ -59,7 +59,11 @@ ${fontsBlock}${bundledBlock}<script type="importmap">${escapeJsonScript(importMa
  * point — top-level element down to the deepest, each with its selector,
  * geometry, and nearest data-spool-source stamp (#23) — the canvas walks it
  * Figma-style (double-click descends, Esc ascends) without ever handing the
- * frame the pointer; {spool:"sites"} answers with the frame-local boxes of
+ * frame the pointer; {spool:"tree?"} answers with the whole live DOM below
+ * the boot root, each element carrying its own stamp (#37) — the sidebar
+ * tree's source; {spool:"describe", selectors} answers with one ancestry
+ * chain per selector so tree rows become canvas selections;
+ * {spool:"sites"} answers with the frame-local boxes of
  * navigation-site elements (#34) so arrows grow out of what causes them.
  * Entered frames also hand canvas-zoom gestures back across
  * the iframe boundary; ordinary wheel input stays inside the frame so its own
@@ -170,10 +174,8 @@ const canvasShimJs = `(() => {
 		};
 	}
 
-	// the ancestry at the point, top-level element first, deepest last
-	function pickChain(x, y) {
-		const el = document.elementFromPoint ? document.elementFromPoint(x, y) : null;
-		if (!el || el === document.documentElement || el === document.body || el.id === "root") return [];
+	// the ancestry of one element, top-level element first, deepest last
+	function chainOf(el) {
 		const line = [];
 		let node = el;
 		while (node && node.nodeType === 1 && node !== document.documentElement && node !== document.body && node.id !== "root") {
@@ -181,6 +183,33 @@ const canvasShimJs = `(() => {
 			node = node.parentElement;
 		}
 		return line.map(hitOf);
+	}
+
+	// the ancestry at the point
+	function pickChain(x, y) {
+		const el = document.elementFromPoint ? document.elementFromPoint(x, y) : null;
+		if (!el || el === document.documentElement || el === document.body || el.id === "root") return [];
+		return chainOf(el);
+	}
+
+	// direct text children only (#37): a wrapper never wears its descendants' words
+	function textOf(el) {
+		let out = "";
+		for (const node of el.childNodes) if (node.nodeType === 3) out += node.textContent;
+		out = out.replace(/\\s+/g, " ").trim();
+		return out.length > 60 ? out.slice(0, 59) + "\\u2026" : out;
+	}
+
+	// the live DOM below the boot root (#37): every element, its own stamp only —
+	// grouping and boundaries are the canvas's read of the stamps
+	function rawTree(el) {
+		return {
+			tag: el.tagName.toLowerCase(),
+			selector: cssPath(el),
+			source: el.getAttribute("data-spool-source"),
+			text: textOf(el),
+			children: Array.from(el.children).map(rawTree),
+		};
 	}
 
 	// where each navigation site's element sits (#34): stamp match first, and
@@ -230,6 +259,30 @@ const canvasShimJs = `(() => {
 			let boxes = {};
 			try { boxes = siteBoxes(m.sites); } catch {}
 			parent.postMessage({ spool: "site-boxes", frame, id: m.id, boxes }, "*");
+			return;
+		}
+		if (m.spool === "tree?") {
+			const frame = (window.__SPOOL__ || {}).frame;
+			let roots = [];
+			try {
+				const root = document.getElementById("root");
+				roots = root ? Array.from(root.children).map(rawTree) : [];
+			} catch {}
+			parent.postMessage({ spool: "tree", frame, id: m.id, roots }, "*");
+			return;
+		}
+		if (m.spool === "describe") {
+			const frame = (window.__SPOOL__ || {}).frame;
+			let chains = [];
+			try {
+				chains = (Array.isArray(m.selectors) ? m.selectors : []).map((sel) => {
+					let el = null;
+					try { el = typeof sel === "string" ? document.querySelector(sel) : null; } catch {}
+					if (!el || el.id === "root") return [];
+					return chainOf(el);
+				});
+			} catch {}
+			parent.postMessage({ spool: "described", frame, id: m.id, chains }, "*");
 			return;
 		}
 		if (m.spool !== "capture") return;

--- a/src/daemon/hands-api.test.ts
+++ b/src/daemon/hands-api.test.ts
@@ -57,13 +57,15 @@ describe("the selection API", () => {
 		const put = await app.request(
 			`/api/p/${name}/selection`,
 			jsonPut({
-				element: {
-					frame: "checkout",
-					selector: "main > button",
-					outerHtml: '<button class="pay">Pay now</button>',
-					source: "frames/checkout/frame.tsx:4:4",
-					generated: false,
-				},
+				elements: [
+					{
+						frame: "checkout",
+						selector: "main > button",
+						outerHtml: '<button class="pay">Pay now</button>',
+						source: "frames/checkout/frame.tsx:4:4",
+						generated: false,
+					},
+				],
 			}),
 		);
 		expect(put.status).toBe(204);
@@ -82,6 +84,44 @@ describe("the selection API", () => {
 		});
 	});
 
+	it("serves a multi-element selection as one entry per element, in put order", async () => {
+		const spoolDir = join(makeTempDir(), ".spool");
+		const { root, name } = makeProject(spoolDir);
+		writeFrame(root, "checkout", frameTsx);
+		const app = makeApp(spoolDir);
+
+		const put = await app.request(
+			`/api/p/${name}/selection`,
+			jsonPut({
+				elements: [
+					{
+						frame: "checkout",
+						selector: "main > button",
+						outerHtml: '<button class="pay">Pay now</button>',
+						source: "frames/checkout/frame.tsx:4:4",
+						generated: false,
+					},
+					{
+						frame: "checkout",
+						selector: "main",
+						outerHtml: "<main></main>",
+						source: "frames/checkout/frame.tsx:3:3",
+						generated: false,
+					},
+				],
+			}),
+		);
+		expect(put.status).toBe(204);
+
+		const { selection } = (await (await app.request(`/api/p/${name}/selection`)).json()) as {
+			selection: Array<Record<string, unknown>>;
+		};
+		expect(selection.map((entry) => [entry.kind, entry.selector, entry.lines])).toEqual([
+			["element", "main > button", [4, 4]],
+			["element", "main", [3, 5]],
+		]);
+	});
+
 	it("degrades generated elements honestly: ancestor lines, live outerHTML excerpt", async () => {
 		const spoolDir = join(makeTempDir(), ".spool");
 		const { root, name } = makeProject(spoolDir);
@@ -91,13 +131,15 @@ describe("the selection API", () => {
 		await app.request(
 			`/api/p/${name}/selection`,
 			jsonPut({
-				element: {
-					frame: "checkout",
-					selector: "main > ul > li:nth-of-type(2)",
-					outerHtml: "<li>b</li>",
-					source: "frames/checkout/frame.tsx:3:3",
-					generated: true,
-				},
+				elements: [
+					{
+						frame: "checkout",
+						selector: "main > ul > li:nth-of-type(2)",
+						outerHtml: "<li>b</li>",
+						source: "frames/checkout/frame.tsx:3:3",
+						generated: true,
+					},
+				],
 			}),
 		);
 
@@ -122,13 +164,15 @@ describe("the selection API", () => {
 		await app.request(
 			`/api/p/${name}/selection`,
 			jsonPut({
-				element: {
-					frame: "checkout",
-					selector: "main > i",
-					outerHtml: "<i>x</i>",
-					source: "../../secrets.txt:1:1",
-					generated: false,
-				},
+				elements: [
+					{
+						frame: "checkout",
+						selector: "main > i",
+						outerHtml: "<i>x</i>",
+						source: "../../secrets.txt:1:1",
+						generated: false,
+					},
+				],
 			}),
 		);
 
@@ -151,6 +195,8 @@ describe("the selection API", () => {
 		expect((await app.request(`/api/p/${name}/selection`, jsonPut({}))).status).toBe(400);
 		expect((await app.request(`/api/p/${name}/selection`, jsonPut({ frames: ["../escape"] }))).status).toBe(400);
 		expect((await app.request(`/api/p/${name}/selection`, jsonPut({ frames: [42] }))).status).toBe(400);
+		expect((await app.request(`/api/p/${name}/selection`, jsonPut({ elements: [{ frame: "x" }] }))).status).toBe(400);
+		expect((await app.request(`/api/p/${name}/selection`, jsonPut({ elements: "main" }))).status).toBe(400);
 	});
 
 	it("drops selected frames that no longer exist instead of fabricating entries", async () => {

--- a/src/daemon/hands-api.test.ts
+++ b/src/daemon/hands-api.test.ts
@@ -214,6 +214,57 @@ describe("the selection API", () => {
 	});
 });
 
+describe("the stamp labels API", () => {
+	const listTsx = `const items = ["a", "b"];
+export default function Frame() {
+	return (
+		<ul>
+			{items.map((item) => (
+				<li key={item}>{item}</li>
+			))}
+		</ul>
+	);
+}
+`;
+
+	it("labels repeated stamps from their call site and nulls the rest", async () => {
+		const spoolDir = join(makeTempDir(), ".spool");
+		const { root, name } = makeProject(spoolDir);
+		writeFrame(root, "list", listTsx);
+		const app = makeApp(spoolDir);
+
+		const res = await app.request(
+			`/api/p/${name}/stamp-labels`,
+			jsonPost({
+				stamps: [
+					"frames/list/frame.tsx:6:5",
+					"frames/list/frame.tsx:4:3",
+					"../../escape.tsx:1:1",
+					"frames/ghost/frame.tsx:1:1",
+				],
+			}),
+		);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			labels: {
+				"frames/list/frame.tsx:6:5": "items.map(…)",
+				"frames/list/frame.tsx:4:3": null,
+				"../../escape.tsx:1:1": null,
+				"frames/ghost/frame.tsx:1:1": null,
+			},
+		});
+	});
+
+	it("rejects a shapeless ask", async () => {
+		const spoolDir = join(makeTempDir(), ".spool");
+		const { name } = makeProject(spoolDir);
+		const app = makeApp(spoolDir);
+
+		expect((await app.request(`/api/p/${name}/stamp-labels`, jsonPost({}))).status).toBe(400);
+		expect((await app.request(`/api/p/${name}/stamp-labels`, jsonPost({ stamps: [7] }))).status).toBe(400);
+	});
+});
+
 describe("the geometry API", () => {
 	it("writes moved and resized geometry to the sidecar alone — frame source untouched", async () => {
 		const spoolDir = join(makeTempDir(), ".spool");

--- a/src/daemon/jsx-span.ts
+++ b/src/daemon/jsx-span.ts
@@ -35,7 +35,7 @@ export function extractJsxSpan(source: string, line: number, column: number): Js
 }
 
 /** 1-based line/column to string offset; undefined when out of range. */
-function offsetOf(source: string, line: number, column: number): number | undefined {
+export function offsetOf(source: string, line: number, column: number): number | undefined {
 	let lineStart = 0;
 	for (let n = 1; n < line; n++) {
 		const next = source.indexOf("\n", lineStart);

--- a/src/daemon/selection.ts
+++ b/src/daemon/selection.ts
@@ -26,18 +26,17 @@ export type SelectionEntry =
 			generated?: true;
 	  };
 
-/** The canvas's wire shape: a frame list, or one element as the shim saw it. */
-export type SelectionPut =
-	| { frames: string[] }
-	| {
-			element: {
-				frame: string;
-				selector: string;
-				outerHtml: string;
-				source: string | null;
-				generated: boolean;
-			};
-	  };
+/** One element as the shim saw it — the canvas sends a list of these. */
+export interface ElementPut {
+	frame: string;
+	selector: string;
+	outerHtml: string;
+	source: string | null;
+	generated: boolean;
+}
+
+/** The canvas's wire shape: a frame list, or the picked elements in pick order. */
+export type SelectionPut = { frames: string[] } | { elements: ElementPut[] };
 
 const EXCERPT_CAP = 240;
 
@@ -50,14 +49,18 @@ export function parseSelectionPut(value: unknown): SelectionPut | undefined {
 		}
 		return { frames: record.frames };
 	}
-	const element = record.element as Record<string, unknown> | undefined;
-	if (typeof element !== "object" || element === null) return undefined;
-	const { frame, selector, outerHtml, source, generated } = element;
-	if (typeof frame !== "string" || !isSafeName(frame)) return undefined;
-	if (typeof selector !== "string" || typeof outerHtml !== "string") return undefined;
-	if (source !== null && typeof source !== "string") return undefined;
-	if (typeof generated !== "boolean") return undefined;
-	return { element: { frame, selector, outerHtml, source, generated } };
+	if (!Array.isArray(record.elements)) return undefined;
+	const elements: ElementPut[] = [];
+	for (const element of record.elements) {
+		if (typeof element !== "object" || element === null) return undefined;
+		const { frame, selector, outerHtml, source, generated } = element as Record<string, unknown>;
+		if (typeof frame !== "string" || !isSafeName(frame)) return undefined;
+		if (typeof selector !== "string" || typeof outerHtml !== "string") return undefined;
+		if (source !== null && typeof source !== "string") return undefined;
+		if (typeof generated !== "boolean") return undefined;
+		elements.push({ frame, selector, outerHtml, source, generated });
+	}
+	return { elements };
 }
 
 export function createSelectionStore() {
@@ -92,16 +95,24 @@ function enrich(root: string, put: SelectionPut): SelectionEntry[] {
 			];
 		});
 	}
+	return put.elements.map((element) => elementEntry(root, element));
+}
 
-	const { frame, selector, outerHtml, source, generated } = put.element;
+function elementEntry(root: string, { frame, selector, outerHtml, source, generated }: ElementPut): SelectionEntry {
 	const found = lookupFrame(root, frame);
 	const framePath = framePathOf(frame, found.kind === "found" ? found.page : undefined);
 	const stamp = source === null ? undefined : parseStamp(root, source);
 	if (stamp === undefined) {
 		// no stamp anywhere: JS-created DOM under an unstamped root (#6 degrade)
-		return [
-			{ kind: "element", frame, path: framePath, lines: [1, 1], selector, excerpt: cap(outerHtml), generated: true },
-		];
+		return {
+			kind: "element",
+			frame,
+			path: framePath,
+			lines: [1, 1],
+			selector,
+			excerpt: cap(outerHtml),
+			generated: true,
+		};
 	}
 
 	const span = spanOf(stamp);
@@ -110,7 +121,7 @@ function enrich(root: string, put: SelectionPut): SelectionEntry[] {
 	// is the excerpt, the stamped ancestor lends its lines
 	const excerpt = generated ? cap(outerHtml) : (span?.excerpt ?? sourceLine(stamp) ?? cap(outerHtml));
 	const entry: SelectionEntry = { kind: "element", frame, path: `design/${stamp.rel}`, lines, selector, excerpt };
-	return [generated ? { ...entry, generated: true } : entry];
+	return generated ? { ...entry, generated: true } : entry;
 }
 
 /** The frame's own source path, wherever its page put the folder (#39). */

--- a/src/daemon/selection.ts
+++ b/src/daemon/selection.ts
@@ -129,7 +129,7 @@ function framePathOf(frame: string, page: string | undefined): string {
 	return `design/${frameFolder(frame, page)}/frame.tsx`;
 }
 
-interface Stamp {
+export interface Stamp {
 	file: string;
 	rel: string;
 	line: number;
@@ -141,7 +141,7 @@ interface Stamp {
  * DOM attributes, so anything malformed or escaping design/ reads as no
  * stamp at all — the entry degrades, the read never leaves the project.
  */
-function parseStamp(root: string, source: string): Stamp | undefined {
+export function parseStamp(root: string, source: string): Stamp | undefined {
 	const match = source.match(/^(.+):(\d+):(\d+)$/);
 	const [, raw, lineText, columnText] = match ?? [];
 	if (raw === undefined || lineText === undefined || columnText === undefined) return undefined;

--- a/src/runtime/canvas-shim.test.ts
+++ b/src/runtime/canvas-shim.test.ts
@@ -32,18 +32,20 @@ function runShim(shim: string): void {
 	new Function(shim)();
 }
 
-/** The next {spool:"picked"} reply — parent === window here, so it echoes back. */
-function nextPicked(): Promise<unknown> {
+/** The next reply of one spool kind — parent === window here, so it echoes back. */
+function nextReply(kind: string): Promise<unknown> {
 	return new Promise((resolve) => {
 		const onMessage = (event: MessageEvent) => {
 			const data = event.data as { spool?: string } | null;
-			if (data === null || typeof data !== "object" || data.spool !== "picked") return;
+			if (data === null || typeof data !== "object" || data.spool !== kind) return;
 			window.removeEventListener("message", onMessage);
 			resolve(data);
 		};
 		window.addEventListener("message", onMessage);
 	});
 }
+
+const nextPicked = () => nextReply("picked");
 
 describe("the freeze shim", () => {
 	it("claims canvas zoom gestures that start inside an entered frame", async () => {
@@ -183,6 +185,64 @@ describe("the freeze shim", () => {
 		picked = nextPicked();
 		window.postMessage({ spool: "pick", x: 1, y: 1 }, "*");
 		expect(((await picked) as { chain: unknown }).chain).toEqual([]);
+	});
+
+	it("answers a tree walk with own stamps, direct text, and children in DOM order", async () => {
+		const shim = await servedShim();
+		runShim(shim);
+		document.body.innerHTML = `<div id="root"><main data-spool-source="frames/host/frame.tsx:3:3">
+			<button data-spool-source="frames/host/frame.tsx:4:4">Pay <b>now</b></button>
+			<ul data-spool-source="frames/host/frame.tsx:6:4"><li>a</li><li>b</li></ul>
+		</main></div>`;
+
+		const tree = nextReply("tree");
+		window.postMessage({ spool: "tree?", id: 9 }, "*");
+
+		const reply = (await tree) as { id: number; roots: Array<Record<string, unknown>> };
+		expect(reply.id).toBe(9);
+		expect(reply.roots).toHaveLength(1);
+		const main = reply.roots[0] as { children: Array<Record<string, unknown>> } & Record<string, unknown>;
+		expect(main).toMatchObject({ tag: "main", selector: "main", source: "frames/host/frame.tsx:3:3", text: "" });
+		expect(main.children).toHaveLength(2);
+		// direct text only — the nested <b> stays its own node, li's stay unstamped
+		expect(main.children[0]).toMatchObject({
+			tag: "button",
+			selector: "main > button",
+			source: "frames/host/frame.tsx:4:4",
+			text: "Pay",
+		});
+		expect((main.children[0] as { children: unknown[] }).children).toHaveLength(1);
+		expect(main.children[1]).toMatchObject({ tag: "ul", source: "frames/host/frame.tsx:6:4" });
+		expect((main.children[1] as { children: Array<Record<string, unknown>> }).children[1]).toMatchObject({
+			tag: "li",
+			selector: "main > ul > li:nth-of-type(2)",
+			source: null,
+			text: "b",
+		});
+	});
+
+	it("answers describe with one ancestry chain per selector, empty for a miss", async () => {
+		const shim = await servedShim();
+		runShim(shim);
+		document.body.innerHTML = `<div id="root"><main data-spool-source="frames/host/frame.tsx:3:3">
+			<button data-spool-source="frames/host/frame.tsx:4:4">Pay now</button>
+		</main></div>`;
+
+		const described = nextReply("described");
+		window.postMessage({ spool: "describe", selectors: ["main > button", "main > ghost"], id: 11 }, "*");
+
+		const reply = (await described) as { id: number; chains: Array<Array<Record<string, unknown>>> };
+		expect(reply.id).toBe(11);
+		expect(reply.chains).toHaveLength(2);
+		expect(reply.chains[0]).toHaveLength(2);
+		expect(reply.chains[0]?.[0]).toMatchObject({ selector: "main", tag: "main" });
+		expect(reply.chains[0]?.[1]).toMatchObject({
+			selector: "main > button",
+			tag: "button",
+			source: "frames/host/frame.tsx:4:4",
+			generated: false,
+		});
+		expect(reply.chains[1]).toEqual([]);
 	});
 
 	it("skips setInterval ticks while frozen", async () => {

--- a/src/ui/api.ts
+++ b/src/ui/api.ts
@@ -151,6 +151,17 @@ export function beaconTrash(project: string, frames: string[]): void {
 	);
 }
 
+/** The tree's call-site rows (#37): each stamp's repeating call, or null. */
+export async function fetchStampLabels(project: string, stamps: string[]): Promise<Record<string, string | null>> {
+	try {
+		const res = await client.api.p[":project"]["stamp-labels"].$post({ param: { project }, json: { stamps } });
+		if (!res.ok) return {};
+		return ((await res.json()) as { labels: Record<string, string | null> }).labels;
+	} catch {
+		return {};
+	}
+}
+
 export function openInEditor(project: string, path: string, line?: number): void {
 	void client.api.p[":project"].editor.$post({
 		param: { project },

--- a/src/ui/canvas/canvas.tsx
+++ b/src/ui/canvas/canvas.tsx
@@ -7,6 +7,7 @@ import {
 	fetchCanvasState,
 	fetchFlows,
 	fetchProjection,
+	fetchStampLabels,
 	openInEditor,
 	postTrash,
 	postWalk,
@@ -21,6 +22,7 @@ import { RibbonMark } from "../icons";
 import { type Box, boundsOf, centerOn, clamp, fitCamera, intersects, toWorld, zoomAt } from "./camera";
 import { CollisionNotice } from "./collision-notice";
 import { ContextMenu, contextMenuSize } from "./context-menu";
+import { buildTreeRows, revealKeys, rowSelectors, type TreeRow, visibleRows } from "./element-tree";
 import { ExportDialog, type ExportFormat } from "./export-dialog";
 import { type ExportNotice, ExportToast } from "./export-toast";
 import { anchorKeyOf, FlowArrows, type SiteBoxesByFrame } from "./flow-arrows";
@@ -43,11 +45,13 @@ import {
 	isHandle,
 	NO_GUIDES,
 	type PickedSelection,
+	pickKey,
 	SelectionOverlay,
 } from "./overlays";
 import {
 	camerasFromState,
 	frameSourcePath,
+	frameSourceRel,
 	pageOf,
 	portalEdges,
 	ROOT_PAGE,
@@ -57,15 +61,19 @@ import {
 } from "./pages";
 import { PortalChips } from "./portal-chips";
 import {
+	describeMessage,
 	type PickedHit,
 	parseFrameMessage,
+	parseStampRef,
 	pickMessage,
+	type RawTreeNode,
 	type SessionRecord,
 	type SiteAnchor,
 	sessionReply,
 	sitesMessage,
+	treeMessage,
 } from "./protocol";
-import { CanvasSidebar } from "./sidebar";
+import { CanvasSidebar, type SelectModifiers } from "./sidebar";
 import { snapEdge, snapMovedBox } from "./snap";
 import { nextSpatialFrame, type SpatialDirection } from "./spatial-navigation";
 import { TrashToast } from "./trash-toast";
@@ -77,8 +85,10 @@ import { TrashToast } from "./trash-toast";
  * click selects the frame (or, inside an element scope, the sibling at that
  * depth), double click goes deeper — into running time in live (the entered
  * state then follows data-go walks, #5), one element level per click in
- * design, where ⌘-click jumps to the deepest element and Esc ascends back
- * out. Hands obey the one law: move, resize and nudge write
+ * design, where ⌘-click jumps to the deepest element, shift-click toggles
+ * elements in and out of a multi-selection, hover previews the would-be
+ * target (#37), and Esc ascends back out — a multi-selection drops straight
+ * to its frames. Hands obey the one law: move, resize and nudge write
  * geometry sidecars only; delete rides the OS Trash behind a toast-undo; the
  * canvas never writes frame source.
  */
@@ -124,6 +134,10 @@ const SELECTION_PUT_MS = 150;
 const PICK_REPLY_MS = 400;
 const TRASH_UNDO_MS = 5000;
 const HOVER_PICK_MS = 80;
+const TREE_REPLY_MS = 1000;
+const STAMP_LABEL_BATCH = 256;
+
+const NO_WAKES: ReadonlySet<string> = new Set();
 
 function spatialDirection(key: string): SpatialDirection | undefined {
 	switch (key) {
@@ -196,6 +210,11 @@ export function ProjectCanvas({
 	const [pages, setPages] = useState<string[]>([]);
 	const [activePage, setActivePage] = useState<string>(ROOT_PAGE);
 	const [collisions, setCollisions] = useState<FrameCollision[]>([]);
+	// the sidebar tree (#37): per-frame raw walks, row expansion, call-site labels
+	const [trees, setTrees] = useState<Record<string, RawTreeNode[]>>({});
+	const [expandedFrames, setExpandedFrames] = useState<ReadonlySet<string>>(new Set<string>());
+	const [expandedRows, setExpandedRows] = useState<ReadonlySet<string>>(new Set<string>());
+	const [callSiteLabels, setCallSiteLabels] = useState<Record<string, string | null>>({});
 
 	// the active page is the canvas: only its frames mount — and frames staged
 	// for the Trash vanish instantly; the disk move waits on the toast
@@ -255,6 +274,12 @@ export function ProjectCanvas({
 	// hover picks ride pointer-move (#37): throttled, one in flight at a time
 	const hoverLast = useRef(0);
 	const hoverBusy = useRef(false);
+	// tree and describe round-trips (#37), pickWaiters' pattern
+	const treeWaiters = useRef(new Map<number, (roots: RawTreeNode[]) => void>());
+	const describeWaiters = useRef(new Map<number, (chains: PickedHit[][]) => void>());
+	// the panel's range anchors (#37): one per list, ranges never cross lists
+	const frameAnchor = useRef<string | null>(null);
+	const rowAnchor = useRef<{ frame: string; key: string } | null>(null);
 	const nudgeDirty = useRef(new Set<string>());
 	const nudgeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 	const trashTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -287,6 +312,14 @@ export function ProjectCanvas({
 		[project, noteThumb],
 	);
 
+	// expand is attention (#37): an expanded tree row wakes its frame through
+	// the queue and keeps it real while the row stays open
+	const wakeRequested = useMemo<ReadonlySet<string>>(() => {
+		if (mode !== "design") return NO_WAKES;
+		const names = [...expandedFrames].filter((name) => visibleFrames.some((f) => f.name === name));
+		return names.length === 0 ? NO_WAKES : new Set(names);
+	}, [mode, expandedFrames, visibleFrames]);
+
 	const lifecycle = useFrameLifecycle({
 		framesRef,
 		cameraRef,
@@ -295,6 +328,7 @@ export function ProjectCanvas({
 		entered,
 		// first click pre-boots (#8) — a hint that only means one thing at a time
 		selected: selected.length === 1 ? (selected[0] ?? null) : null,
+		wakeRequested,
 		hasThumb: (name) => hasThumbRef.current(name),
 		onShot,
 	});
@@ -877,6 +911,233 @@ export function ProjectCanvas({
 		[beginPick, atDepthIn],
 	);
 
+	// --- element tree (#37): the sidebar's rows, extracted from live DOM --------
+
+	const treeBusy = useRef(new Set<string>());
+	const labelsAsked = useRef(new Set<string>());
+
+	/** Ask one frame's shim for its raw DOM walk; the newest answer stands. */
+	const requestTree = useCallback((frame: string) => {
+		const target = iframes.current.get(frame)?.contentWindow;
+		if (target == null || treeBusy.current.has(frame)) return;
+		treeBusy.current.add(frame);
+		const id = ++pickSeq.current;
+		treeWaiters.current.set(id, (roots) => {
+			treeBusy.current.delete(frame);
+			setTrees((current) => ({ ...current, [frame]: roots }));
+		});
+		target.postMessage(treeMessage(id), "*");
+		setTimeout(() => {
+			if (treeWaiters.current.delete(id)) treeBusy.current.delete(frame);
+		}, TREE_REPLY_MS);
+	}, []);
+
+	useEffect(() => {
+		if (mode !== "design") return;
+		for (const name of expandedFrames) {
+			if (trees[name] === undefined && lifecycle.ready.has(name)) requestTree(name);
+		}
+	}, [mode, expandedFrames, trees, lifecycle.ready, requestTree]);
+
+	// a hibernated frame's cached walk is a lie — the next expand re-asks
+	useEffect(() => {
+		setTrees((current) => {
+			const dead = Object.keys(current).filter((name) => (lifecycle.states[name] ?? "hibernated") === "hibernated");
+			if (dead.length === 0) return current;
+			return Object.fromEntries(Object.entries(current).filter(([name]) => !dead.includes(name)));
+		});
+	}, [lifecycle.states]);
+
+	const rowsByFrame = useMemo(() => {
+		const out: Record<string, TreeRow[]> = {};
+		for (const [name, roots] of Object.entries(trees)) {
+			out[name] = buildTreeRows(roots, frameSourceRel(name, activePage));
+		}
+		return out;
+	}, [trees, activePage]);
+
+	// call-site rows name themselves from source (#37): fetch labels once each,
+	// batched to the endpoint's cap — a failed batch un-asks so a later pass retries
+	useEffect(() => {
+		const missing = new Set<string>();
+		for (const rows of Object.values(rowsByFrame)) collectCallSites(rows, missing);
+		const wanted = [...missing].filter((stamp) => !labelsAsked.current.has(stamp));
+		if (wanted.length === 0) return;
+		for (const stamp of wanted) labelsAsked.current.add(stamp);
+		for (const batch of chunked(wanted, STAMP_LABEL_BATCH)) {
+			void fetchStampLabels(project, batch).then((labels) => {
+				if (Object.keys(labels).length === 0) {
+					for (const stamp of batch) labelsAsked.current.delete(stamp);
+					return;
+				}
+				setCallSiteLabels((current) => ({ ...current, ...labels }));
+			});
+		}
+	}, [rowsByFrame, project]);
+
+	/**
+	 * Rows become canvas selection through a describe round-trip: the frame
+	 * answers each selector's ancestry, the deepest hit is the selection and
+	 * the last chain becomes the scope Esc ascends. Additive keeps prior picks.
+	 */
+	const selectSelectors = useCallback((frame: string, selectors: string[], additive: boolean) => {
+		if (selectors.length === 0) return;
+		const target = iframes.current.get(frame)?.contentWindow;
+		if (target == null) return;
+		const id = ++pickSeq.current;
+		const gen = pickGen.current;
+		describeWaiters.current.set(id, (chains) => {
+			if (pickGen.current !== gen) return;
+			const hits: PickedSelection[] = [];
+			let lastChain: PickedHit[] | null = null;
+			for (const chain of chains) {
+				const hit = chain[chain.length - 1];
+				if (hit === undefined) continue;
+				hits.push({ frame, ...hit });
+				lastChain = chain;
+			}
+			if (hits.length === 0) return;
+			if (lastChain !== null) pickedChain.current = { frame, chain: lastChain };
+			setSelected([]);
+			setPicked(additive ? mergePicks(pickedRef.current, hits) : hits);
+		});
+		target.postMessage(describeMessage(selectors, id), "*");
+		setTimeout(() => describeWaiters.current.delete(id), PICK_REPLY_MS);
+	}, []);
+
+	const toggleFrameRow = (name: string) => {
+		setExpandedFrames((current) => {
+			const next = new Set(current);
+			if (next.has(name)) next.delete(name);
+			else next.add(name);
+			return next;
+		});
+	};
+
+	const toggleTreeRow = (key: string) => {
+		setExpandedRows((current) => {
+			const next = new Set(current);
+			if (next.has(key)) next.delete(key);
+			else next.add(key);
+			return next;
+		});
+	};
+
+	/** The panel grammar on frame rows: shift ranges, ⌘ toggles, click replaces. */
+	const selectFrameRow = (name: string, modifiers: SelectModifiers) => {
+		setPicked([]);
+		pickedChain.current = null;
+		if (modifiers.shift && frameAnchor.current !== null) {
+			const names = visibleFrames.map((f) => f.name);
+			const a = names.indexOf(frameAnchor.current);
+			const b = names.indexOf(name);
+			if (a !== -1 && b !== -1) {
+				const range = names.slice(Math.min(a, b), Math.max(a, b) + 1);
+				setSelected(modifiers.toggle ? [...new Set([...selectedRef.current, ...range])] : range);
+				return;
+			}
+		}
+		frameAnchor.current = name;
+		if (modifiers.toggle) {
+			setSelected((current) => (current.includes(name) ? current.filter((n) => n !== name) : [...current, name]));
+		} else {
+			setSelected([name]);
+		}
+	};
+
+	/** The same grammar on tree rows; ranges run over one frame's visible rows. */
+	const selectTreeRow = (frame: string, row: TreeRow, modifiers: SelectModifiers) => {
+		// a boundary is a file marker, not an element: its click is its chevron's
+		if (row.kind === "boundary") {
+			toggleTreeRow(row.key);
+			return;
+		}
+		if (modifiers.shift && rowAnchor.current?.frame === frame) {
+			const visible = visibleRows(rowsByFrame[frame] ?? [], expandedRows);
+			const a = visible.findIndex((candidate) => candidate.key === rowAnchor.current?.key);
+			const b = visible.findIndex((candidate) => candidate.key === row.key);
+			if (a !== -1 && b !== -1) {
+				const range = visible.slice(Math.min(a, b), Math.max(a, b) + 1);
+				const selectors = [...new Set(range.flatMap((member) => rowSelectors(member)))];
+				selectSelectors(frame, selectors, modifiers.toggle);
+				return;
+			}
+		}
+		rowAnchor.current = { frame, key: row.key };
+		const selectors = rowSelectors(row);
+		if (modifiers.toggle) {
+			const held = new Set(pickedRef.current.filter((pick) => pick.frame === frame).map((pick) => pick.selector));
+			if (selectors.every((selector) => held.has(selector))) {
+				setPicked(
+					pickedRef.current.filter(
+						(pick) => !(pick.frame === frame && held.has(pick.selector) && selectors.includes(pick.selector)),
+					),
+				);
+				return;
+			}
+			selectSelectors(frame, selectors, true);
+			return;
+		}
+		selectSelectors(frame, selectors, false);
+	};
+
+	/** Double-click on a frame row flies the camera to the frame (#37). */
+	const flyToFrame = (name: string) => {
+		const frame = framesRef.current.find((f) => f.name === name);
+		const viewport = viewportRef.current;
+		if (frame === undefined || viewport === null) return;
+		animateCamera(fitCamera(frame, viewport.clientWidth, viewport.clientHeight));
+	};
+
+	/** Double-click on a tree row jumps the editor to the stamped line. */
+	const openRowInEditor = (frame: string, row: TreeRow) => {
+		if (row.kind === "boundary") {
+			openEditorFor({ path: `design/${row.file}` });
+			return;
+		}
+		const stamp = parseStampRef(row.source);
+		openEditorFor(
+			stamp === undefined
+				? { path: frameSourcePath(frame, activePageRef.current) }
+				: { path: `design/${stamp.rel}`, line: stamp.line },
+		);
+	};
+
+	// canvas picks always have a row to reveal (#37): expand the frame row and
+	// every ancestor — boundary rows included — so sync lands on screen
+	const revealTarget = useMemo(() => {
+		const anchorPick = picked[picked.length - 1];
+		if (mode !== "design" || anchorPick === undefined) return undefined;
+		const rows = rowsByFrame[anchorPick.frame];
+		if (rows === undefined) return undefined;
+		return revealKeys(rows, anchorPick.selector)?.key;
+	}, [mode, picked, rowsByFrame]);
+
+	useEffect(() => {
+		const anchorPick = picked[picked.length - 1];
+		if (mode !== "design" || anchorPick === undefined) return;
+		setExpandedFrames((current) =>
+			current.has(anchorPick.frame) ? current : new Set(current).add(anchorPick.frame),
+		);
+		const rows = rowsByFrame[anchorPick.frame];
+		if (rows === undefined) return;
+		const reveal = revealKeys(rows, anchorPick.selector);
+		if (reveal === undefined) return;
+		setExpandedRows((current) => {
+			if (reveal.ancestors.every((key) => current.has(key))) return current;
+			return new Set([...current, ...reveal.ancestors]);
+		});
+	}, [mode, picked, rowsByFrame]);
+
+	// a quiet pending state (#37): expanded, but the DOM has not answered yet
+	const pendingWakes = useMemo<ReadonlySet<string>>(() => {
+		if (mode !== "design") return NO_WAKES;
+		const pending = [...expandedFrames].filter(
+			(name) => visibleFrames.some((f) => f.name === name) && rowsByFrame[name] === undefined,
+		);
+		return pending.length === 0 ? NO_WAKES : new Set(pending);
+	}, [mode, expandedFrames, visibleFrames, rowsByFrame]);
+
 	// --- pages (#39): one canvas per page, cameras bookkept per page ------------
 
 	/** The camera that lands an arrival centered on its target, zoom kept. */
@@ -988,12 +1249,13 @@ export function ProjectCanvas({
 					setDocNonces((current) => ({ ...current, [frame]: (current[frame] ?? 0) + 1 }));
 					// an edit reboot is honest — it does not wear a walk's quiet cover
 					setWalkBoots((current) => without(current, frame));
-					// the DOM these picks pointed into is gone
+					// the DOM these picks pointed into is gone — and so is its walk
 					setPicked((current) => {
 						const kept = current.filter((pick) => pick.frame !== frame);
 						return kept.length === current.length ? current : kept;
 					});
 					if (pickedChain.current?.frame === frame) pickedChain.current = null;
+					setTrees((current) => without(current, frame));
 					lifecycleRef.current.markStale(frame);
 					void refetchFrames();
 					// an edit moves the graph: edges re-derive, verified marks may drop —
@@ -1009,6 +1271,7 @@ export function ProjectCanvas({
 					setWalkBoots((current) => (Object.keys(current).length === 0 ? current : {}));
 					setPicked([]);
 					pickedChain.current = null;
+					setTrees((current) => (Object.keys(current).length === 0 ? current : {}));
 					void refetchFrames();
 				} else if (event.kind === "geometry") {
 					// another browser's hands (or our own echo); ours are the truth
@@ -1065,6 +1328,18 @@ export function ProjectCanvas({
 					const waiter = pickWaiters.current.get(message.id);
 					pickWaiters.current.delete(message.id);
 					waiter?.(message.chain);
+					return;
+				}
+				case "tree": {
+					const waiter = treeWaiters.current.get(message.id);
+					treeWaiters.current.delete(message.id);
+					waiter?.(message.roots);
+					return;
+				}
+				case "described": {
+					const waiter = describeWaiters.current.get(message.id);
+					describeWaiters.current.delete(message.id);
+					waiter?.(message.chains);
 					return;
 				}
 				case "site-boxes": {
@@ -1725,9 +2000,9 @@ export function ProjectCanvas({
 						pickedChain.current = null;
 						setPicked([]);
 						setSelected(frames);
-					} else if (pickedRef.current.length === 1) {
+					} else if (pickedRef.current[0] !== undefined) {
 						// ascend the ancestry (Figma): element → parent → … → frame → clear
-						const picked = pickedRef.current[0] as PickedSelection;
+						const picked = pickedRef.current[0];
 						const held = pickedChain.current;
 						const depth =
 							held !== null && held.frame === picked.frame
@@ -1811,11 +2086,21 @@ export function ProjectCanvas({
 				activePage={activePage}
 				frames={visibleFrames}
 				selected={selected}
+				mode={mode}
+				picked={picked}
+				rowsByFrame={rowsByFrame}
+				callSiteLabels={callSiteLabels}
+				expandedFrames={expandedFrames}
+				expandedRows={expandedRows}
+				pendingWakes={pendingWakes}
+				revealTarget={revealTarget}
 				onSwitchPage={switchToPage}
-				onSelectFrame={(name) => {
-					setSelected([name]);
-					setPicked([]);
-				}}
+				onSelectFrame={selectFrameRow}
+				onDoubleClickFrame={flyToFrame}
+				onToggleFrame={toggleFrameRow}
+				onSelectRow={selectTreeRow}
+				onDoubleClickRow={openRowInEditor}
+				onToggleRow={toggleTreeRow}
 			/>
 			<div
 				ref={viewportRef}
@@ -2013,4 +2298,25 @@ function without<T>(record: Record<string, T>, key: string): Record<string, T> {
 /** "frame-label" → "frameLabel": dataset keys camel-case their attribute. */
 function camelize(attribute: string): string {
 	return attribute.replace(/-(\w)/g, (_, c: string) => c.toUpperCase());
+}
+
+/** Every call-site stamp in a row tree, folded into one set (#37). */
+function collectCallSites(rows: readonly TreeRow[], into: Set<string>): void {
+	for (const row of rows) {
+		if (row.kind === "callsite") into.add(row.source);
+		collectCallSites(row.children, into);
+	}
+}
+
+/** Prior picks plus the new ones, (frame, selector) identity, order kept. */
+function mergePicks(current: readonly PickedSelection[], additions: readonly PickedSelection[]): PickedSelection[] {
+	const held = new Set(current.map((pick) => pickKey(pick.frame, pick.selector)));
+	return [...current, ...additions.filter((pick) => !held.has(pickKey(pick.frame, pick.selector)))];
+}
+
+/** At most `size` per slice, order kept — the stamp-labels endpoint's cap. */
+function chunked<T>(items: readonly T[], size: number): T[][] {
+	const out: T[][] = [];
+	for (let start = 0; start < items.length; start += size) out.push(items.slice(start, start + size));
+	return out;
 }

--- a/src/ui/canvas/canvas.tsx
+++ b/src/ui/canvas/canvas.tsx
@@ -35,6 +35,7 @@ import { FrameLabel } from "./frame-label";
 import { FrameShell, type WalkBoot } from "./frame-shell";
 import { useFrameLifecycle } from "./lifecycle";
 import {
+	type ElementPreview,
 	editorTarget,
 	type Guides,
 	HANDLE_CURSORS,
@@ -122,6 +123,7 @@ const NUDGE_FLUSH_MS = 400;
 const SELECTION_PUT_MS = 150;
 const PICK_REPLY_MS = 400;
 const TRASH_UNDO_MS = 5000;
+const HOVER_PICK_MS = 80;
 
 function spatialDirection(key: string): SpatialDirection | undefined {
 	switch (key) {
@@ -164,8 +166,10 @@ export function ProjectCanvas({
 	const [camera, setCamera] = useState<Camera | null>(null);
 	const [mode, setMode] = useState<CanvasMode>("live");
 	const [selected, setSelected] = useState<string[]>([]);
-	const [picked, setPicked] = useState<PickedSelection | null>(null);
+	const [picked, setPicked] = useState<PickedSelection[]>([]);
 	const [entered, setEntered] = useState<string | null>(null);
+	// the hover preview (#37): the element a click would target, outlined live
+	const [preview, setPreview] = useState<ElementPreview | null>(null);
 	const [externalLink, setExternalLink] = useState<{ frame: string; href: string } | null>(null);
 	const [spaceDown, setSpaceDown] = useState(false);
 	const [panning, setPanning] = useState(false);
@@ -248,6 +252,9 @@ export function ProjectCanvas({
 	const pickGen = useRef(0);
 	// the ancestry behind the current element selection — Esc ascends it
 	const pickedChain = useRef<{ frame: string; chain: PickedHit[] } | null>(null);
+	// hover picks ride pointer-move (#37): throttled, one in flight at a time
+	const hoverLast = useRef(0);
+	const hoverBusy = useRef(false);
 	const nudgeDirty = useRef(new Set<string>());
 	const nudgeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 	const trashTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -550,7 +557,8 @@ export function ProjectCanvas({
 			walkSession.current = null;
 			setEntered(target);
 			setSelected([]);
-			setPicked(null);
+			setPicked([]);
+			setPreview(null);
 			// the entered frame owns the keyboard from the first moment; a frame
 			// booting right now gets it at its loaded report instead
 			iframes.current.get(target)?.focus();
@@ -570,7 +578,7 @@ export function ProjectCanvas({
 		walkSession.current = null;
 		if (retainFrame && frame !== null) {
 			setSelected([frame]);
-			setPicked(null);
+			setPicked([]);
 		}
 		// Focus can otherwise remain trapped in the now-inert iframe, where the
 		// following arrow would never reach the canvas navigation layer.
@@ -582,7 +590,8 @@ export function ProjectCanvas({
 		(next: CanvasMode) => {
 			if (next === "design") exitEntered();
 			// the element surface is design's; its selection does not outlive it
-			if (next === "live") setPicked(null);
+			if (next === "live") setPicked([]);
+			setPreview(null);
 			setMode(next);
 		},
 		[exitEntered],
@@ -594,9 +603,16 @@ export function ProjectCanvas({
 
 	useEffect(() => {
 		const timer = setTimeout(() => {
-			if (picked !== null) {
-				const { frame, selector, outerHtml, source, generated } = picked;
-				putSelection(project, { element: { frame, selector, outerHtml, source, generated } });
+			if (picked.length > 0) {
+				putSelection(project, {
+					elements: picked.map(({ frame, selector, outerHtml, source, generated }) => ({
+						frame,
+						selector,
+						outerHtml,
+						source,
+						generated,
+					})),
+				});
 			} else {
 				putSelection(project, { frames: selected });
 			}
@@ -681,7 +697,10 @@ export function ProjectCanvas({
 			commitTrash(); // an earlier toast still open commits now — one undo slot (#7)
 			setHidden((current) => new Set([...current, ...names]));
 			setSelected((current) => current.filter((name) => !names.includes(name)));
-			setPicked((current) => (current !== null && names.includes(current.frame) ? null : current));
+			setPicked((current) => {
+				const kept = current.filter((pick) => !names.includes(pick.frame));
+				return kept.length === current.length ? current : kept;
+			});
 			if (enteredRef.current !== null && names.includes(enteredRef.current)) exitEntered();
 			pendingTrashRef.current = names;
 			setPendingTrash(names);
@@ -750,22 +769,51 @@ export function ProjectCanvas({
 		if (hit === undefined) return; // frame background: the frame stays the selection
 		pickedChain.current = { frame, chain };
 		setSelected([]);
-		setPicked({ frame, ...hit });
+		setPicked([{ frame, ...hit }]);
 	}, []);
+
+	/** The anchor of the element scope: the most recent pick, whose chain is held. */
+	const pickAnchor = useCallback((): PickedSelection | undefined => {
+		return pickedRef.current[pickedRef.current.length - 1];
+	}, []);
+
+	/**
+	 * Figma's scope memory as a walk: the element at the anchor's depth under a
+	 * fresh chain — a sibling inside the shared ancestry, the divergence point
+	 * outside it, the top-level element when no scope holds.
+	 */
+	const atDepthIn = useCallback(
+		(frame: string, chain: PickedHit[]): PickedHit | undefined => {
+			if (chain.length === 0) return undefined;
+			const anchor = pickAnchor();
+			const held = pickedChain.current;
+			const prior = anchor !== undefined && anchor.frame === frame && held?.frame === frame ? held.chain : null;
+			const depth = prior === null ? -1 : prior.findIndex((h) => h.selector === anchor?.selector);
+			if (prior === null || depth < 0) return chain[0];
+			// walk the shared ancestry: a full match lands at the scope's
+			// depth (a sibling), a partial one at the divergence point
+			let shared = 0;
+			while (shared < depth && shared < chain.length && prior[shared]?.selector === chain[shared]?.selector) {
+				shared++;
+			}
+			return chain[Math.min(shared, chain.length - 1)];
+		},
+		[pickAnchor],
+	);
 
 	/** Figma's descend: each double-click selects one level deeper under the cursor. */
 	const descendAt = useCallback(
 		(frame: string, local: Point) => {
 			beginPick(frame, local, (chain) => {
-				const current = pickedRef.current;
+				const anchor = pickAnchor();
 				const depth =
-					current !== null && current.frame === frame
-						? chain.findIndex((h) => h.selector === current.selector)
+					anchor !== undefined && anchor.frame === frame
+						? chain.findIndex((h) => h.selector === anchor.selector)
 						: -1;
 				applyPick(frame, chain, chain[Math.min(depth + 1, chain.length - 1)]);
 			});
 		},
-		[beginPick, applyPick],
+		[beginPick, applyPick, pickAnchor],
 	);
 
 	/** Figma's deep select (⌘-click, and the right-click point): the deepest element. */
@@ -777,48 +825,56 @@ export function ProjectCanvas({
 	);
 
 	/**
-	 * Figma's scope memory: while an element is selected, a click selects the
-	 * element at the same depth under the cursor — a sibling inside the shared
-	 * ancestry, the divergence point outside it, the frame on empty space.
+	 * The scoped click: while an element is selected, a click selects the
+	 * element at the same depth under the cursor; empty space (and a frame that
+	 * never answers) pops the selection back to the frame.
 	 */
 	const scopedSelectAt = useCallback(
 		(frame: string, local: Point) => {
-			// empty space and a frame that never answers both pop the selection
-			// back to the frame — a silent document must not trap the scope
 			const pop = () => {
 				pickedChain.current = null;
-				setPicked(null);
+				setPicked([]);
 				setSelected([frame]);
 			};
 			beginPick(
 				frame,
 				local,
 				(chain) => {
-					if (chain.length === 0) {
+					const target = atDepthIn(frame, chain);
+					if (target === undefined) {
 						pop();
 						return;
 					}
-					const current = pickedRef.current;
-					const held = pickedChain.current;
-					const prior = current !== null && held !== null && held.frame === frame ? held.chain : null;
-					const depth =
-						prior === null || current === null ? -1 : prior.findIndex((h) => h.selector === current.selector);
-					if (prior === null || depth < 0) {
-						applyPick(frame, chain, chain[0]);
-						return;
-					}
-					// walk the shared ancestry: a full match lands at the scope's
-					// depth (a sibling), a partial one at the divergence point
-					let shared = 0;
-					while (shared < depth && shared < chain.length && prior[shared]?.selector === chain[shared]?.selector) {
-						shared++;
-					}
-					applyPick(frame, chain, chain[Math.min(shared, chain.length - 1)]);
+					applyPick(frame, chain, target);
 				},
 				pop,
 			);
 		},
-		[beginPick, applyPick],
+		[beginPick, applyPick, atDepthIn],
+	);
+
+	/**
+	 * Shift-click's toggle (#37): the at-depth target in or out of the picked
+	 * set — with ⌘, the deepest. A toggle in moves the anchor; membership is
+	 * (frame, selector) identity.
+	 */
+	const togglePickAt = useCallback(
+		(frame: string, local: Point, deepest: boolean) => {
+			beginPick(frame, local, (chain) => {
+				const target = deepest ? chain[chain.length - 1] : atDepthIn(frame, chain);
+				if (target === undefined) return; // frame background: nothing to toggle
+				const current = pickedRef.current;
+				const held = current.filter((pick) => !(pick.frame === frame && pick.selector === target.selector));
+				if (held.length < current.length) {
+					setPicked(held);
+				} else {
+					pickedChain.current = { frame, chain };
+					setPicked([...current, { frame, ...target }]);
+				}
+				setSelected([]);
+			});
+		},
+		[beginPick, atDepthIn],
 	);
 
 	// --- pages (#39): one canvas per page, cameras bookkept per page ------------
@@ -848,7 +904,8 @@ export function ProjectCanvas({
 			exitEntered();
 			setMenu(null);
 			setSelected([]);
-			setPicked(null);
+			setPicked([]);
+			setPreview(null);
 			setExternalLink(null);
 			stopAnimation();
 			const next = switchPage(cameras.current, activePageRef.current, cameraRef.current, target, arriveAt);
@@ -894,7 +951,7 @@ export function ProjectCanvas({
 			// time runs the moment the walk lands, not after the capture below
 			setEntered(target);
 			setSelected([]);
-			setPicked(null);
+			setPicked([]);
 			const frame = framesRef.current.find((f) => f.name === target);
 			const viewport = viewportRef.current;
 			const cam = cameraRef.current;
@@ -931,8 +988,12 @@ export function ProjectCanvas({
 					setDocNonces((current) => ({ ...current, [frame]: (current[frame] ?? 0) + 1 }));
 					// an edit reboot is honest — it does not wear a walk's quiet cover
 					setWalkBoots((current) => without(current, frame));
-					// the DOM this pick pointed into is gone
-					setPicked((current) => (current?.frame === frame ? null : current));
+					// the DOM these picks pointed into is gone
+					setPicked((current) => {
+						const kept = current.filter((pick) => pick.frame !== frame);
+						return kept.length === current.length ? current : kept;
+					});
+					if (pickedChain.current?.frame === frame) pickedChain.current = null;
 					lifecycleRef.current.markStale(frame);
 					void refetchFrames();
 					// an edit moves the graph: edges re-derive, verified marks may drop —
@@ -946,7 +1007,8 @@ export function ProjectCanvas({
 						return next;
 					});
 					setWalkBoots((current) => (Object.keys(current).length === 0 ? current : {}));
-					setPicked(null);
+					setPicked([]);
+					pickedChain.current = null;
 					void refetchFrames();
 				} else if (event.kind === "geometry") {
 					// another browser's hands (or our own echo); ours are the truth
@@ -1131,6 +1193,42 @@ export function ProjectCanvas({
 		return frame === undefined ? null : { x: world.x - frame.x, y: world.y - frame.y };
 	};
 
+	/**
+	 * The hover previews (#37), on throttled pointer-move: holding ⌘ outlines
+	 * the would-be deepest target under the cursor; inside an element scope,
+	 * plain hover outlines the at-depth target in the scope's own frame.
+	 */
+	const hoverPickAt = (frame: string | null, world: Point, deepest: boolean) => {
+		const scopeFrame = pickedRef.current[pickedRef.current.length - 1]?.frame;
+		if (frame === null || !(deepest || frame === scopeFrame)) {
+			setPreview(null);
+			return;
+		}
+		const now = performance.now();
+		if (hoverBusy.current || now - hoverLast.current < HOVER_PICK_MS) return;
+		const local = frameLocalAt(frame, world);
+		if (local === null) return;
+		hoverLast.current = now;
+		hoverBusy.current = true;
+		beginPick(
+			frame,
+			local,
+			(chain) => {
+				hoverBusy.current = false;
+				if (gesture.current.kind !== "idle") return;
+				const target = deepest ? chain[chain.length - 1] : atDepthIn(frame, chain);
+				setPreview(
+					target === undefined
+						? null
+						: { frame, selector: target.selector, rect: target.rect, radius: target.radius },
+				);
+			},
+			() => {
+				hoverBusy.current = false;
+			},
+		);
+	};
+
 	const cancelGesture = useCallback(() => {
 		const active = gesture.current;
 		gesture.current = { kind: "idle" };
@@ -1166,6 +1264,7 @@ export function ProjectCanvas({
 		if (cam === null || event.button === 2) return;
 		stopAnimation();
 		setMenu(null);
+		setPreview(null); // the press supersedes the hover; its own answer redraws
 		cancelPicks(); // a new press voids earlier picks; its own start a fresh generation
 		// a portal chip owns its click (#39) — capturing here would swallow it
 		if (datasetHit(event.target, "portal") !== null) return;
@@ -1217,15 +1316,23 @@ export function ProjectCanvas({
 			const base = event.shiftKey ? selectedRef.current : [];
 			if (!event.shiftKey) {
 				setSelected([]);
-				setPicked(null);
+				setPicked([]);
 			}
 			gesture.current = { kind: "marquee", start: p, base };
 			return;
 		}
 
+		// inside an element scope, shift toggles membership (#37): the at-depth
+		// target under the cursor, or with ⌘ the deepest — the two hover previews
+		if (modeRef.current === "design" && event.shiftKey && pickedRef.current.length > 0 && label === null) {
+			const local = frameLocalAt(hit, world);
+			if (local !== null) togglePickAt(hit, local, event.metaKey);
+			return;
+		}
+
 		if (event.shiftKey) {
 			// shift-click: add/remove, never a drag
-			setPicked(null);
+			setPicked([]);
 			setSelected((current) => (current.includes(hit) ? current.filter((name) => name !== hit) : [...current, hit]));
 			return;
 		}
@@ -1241,8 +1348,8 @@ export function ProjectCanvas({
 		// inside an element scope the click stays scoped (Figma): the sibling
 		// under the cursor, answered by the frame within a paint or two — and
 		// the double-click this press may begin then descends from that answer
-		const scoped = pickedRef.current;
-		if (modeRef.current === "design" && scoped !== null && scoped.frame === hit && label === null) {
+		const anchor = pickedRef.current[pickedRef.current.length - 1];
+		if (modeRef.current === "design" && anchor !== undefined && anchor.frame === hit && label === null) {
 			const local = frameLocalAt(hit, world);
 			if (local !== null) scopedSelectAt(hit, local);
 			gesture.current = { kind: "pending", names: [hit], origins: originsOf([hit]), start: p };
@@ -1253,17 +1360,24 @@ export function ProjectCanvas({
 		const names = wasSelected ? [...selectedRef.current] : [hit];
 		if (!wasSelected) {
 			setSelected([hit]);
-			setPicked(null);
+			setPicked([]);
 		}
 		gesture.current = { kind: "pending", names, origins: originsOf(names), start: p };
 	};
 
 	const onPointerMove = (event: React.PointerEvent) => {
 		const active = gesture.current;
-		if (active.kind === "idle") return;
 		const cam = cameraRef.current;
 		if (cam === null) return;
 		const p = localPoint(event);
+
+		if (active.kind === "idle") {
+			// idle motion is the hover surface (#37) — design only, never entered
+			if (modeRef.current !== "design" || enteredRef.current !== null || menuOpenRef.current) return;
+			const world = toWorld(p, cam);
+			hoverPickAt(frameAtWorld(world), world, event.metaKey);
+			return;
+		}
 
 		if (active.kind === "pan") {
 			const dx = p.x - active.lastX;
@@ -1278,7 +1392,7 @@ export function ProjectCanvas({
 			// a drag is an arrange (#7): it moves frames, so element scope ends
 			cancelPicks();
 			setSelected(active.names);
-			setPicked(null);
+			setPicked([]);
 			gesture.current = { kind: "move", names: active.names, origins: active.origins, start: active.start };
 			onPointerMove(event);
 			return;
@@ -1435,10 +1549,10 @@ export function ProjectCanvas({
 			return;
 		}
 		if (enteredRef.current !== null) exitEntered();
-		const elementSelection = pickedRef.current?.frame === hit;
+		const elementSelection = pickedRef.current.some((pick) => pick.frame === hit);
 		if (!elementSelection && !selectedRef.current.includes(hit)) {
 			setSelected([hit]);
-			setPicked(null);
+			setPicked([]);
 		}
 		// A context click acts on the existing frame selection. Element picking
 		// belongs to design's click, double-click and ⌘-click gestures.
@@ -1471,7 +1585,7 @@ export function ProjectCanvas({
 	exportingRef.current = exporting;
 
 	useEffect(() => {
-		const pickTarget = () => (pickedRef.current === null ? [] : [pickedRef.current.frame]);
+		const pickTarget = () => [...new Set(pickedRef.current.map((pick) => pick.frame))];
 		const isTyping = (target: EventTarget | null) =>
 			target instanceof HTMLElement &&
 			(target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
@@ -1564,7 +1678,7 @@ export function ProjectCanvas({
 						const target = nextSpatialFrame(current, framesRef.current, direction);
 						if (target === undefined) break;
 						setSelected([target.name]);
-						setPicked(null);
+						setPicked([]);
 						const viewport = viewportRef.current;
 						const cam = cameraRef.current;
 						if (viewport !== null && cam !== null) {
@@ -1601,21 +1715,28 @@ export function ProjectCanvas({
 					break;
 				case "Escape": {
 					cancelPicks();
+					setPreview(null);
 					if (gesture.current.kind !== "idle" && gesture.current.kind !== "pan") cancelGesture();
 					else if (menuOpenRef.current) setMenu(null);
 					else if (enteredRef.current !== null) exitEntered(true);
-					else if (pickedRef.current !== null) {
+					else if (pickedRef.current.length > 1) {
+						// a multi-selection has no one ancestry: drop to its frames
+						const frames = [...new Set(pickedRef.current.map((pick) => pick.frame))];
+						pickedChain.current = null;
+						setPicked([]);
+						setSelected(frames);
+					} else if (pickedRef.current.length === 1) {
 						// ascend the ancestry (Figma): element → parent → … → frame → clear
-						const picked = pickedRef.current;
+						const picked = pickedRef.current[0] as PickedSelection;
 						const held = pickedChain.current;
 						const depth =
 							held !== null && held.frame === picked.frame
 								? held.chain.findIndex((h) => h.selector === picked.selector)
 								: -1;
 						const parent = depth > 0 ? held?.chain[depth - 1] : undefined;
-						if (parent !== undefined) setPicked({ frame: picked.frame, ...parent });
+						if (parent !== undefined) setPicked([{ frame: picked.frame, ...parent }]);
 						else {
-							setPicked(null);
+							setPicked([]);
 							setSelected([picked.frame]);
 						}
 					} else setSelected([]);
@@ -1625,6 +1746,8 @@ export function ProjectCanvas({
 		};
 		const onKeyUp = (event: KeyboardEvent) => {
 			if (event.code === "Space") setSpaceDown(false);
+			// releasing ⌘ outside an element scope ends the deep-hover preview
+			if (event.key === "Meta" && pickedRef.current.length === 0) setPreview(null);
 		};
 		window.addEventListener("keydown", onKeyDown);
 		window.addEventListener("keyup", onKeyUp);
@@ -1691,7 +1814,7 @@ export function ProjectCanvas({
 				onSwitchPage={switchToPage}
 				onSelectFrame={(name) => {
 					setSelected([name]);
-					setPicked(null);
+					setPicked([]);
 				}}
 			/>
 			<div
@@ -1705,6 +1828,7 @@ export function ProjectCanvas({
 				onPointerDown={onPointerDown}
 				onPointerMove={onPointerMove}
 				onPointerUp={onPointerUp}
+				onPointerLeave={() => setPreview(null)}
 				onDoubleClick={onDoubleClick}
 				onContextMenu={onContextMenu}
 			>
@@ -1783,6 +1907,7 @@ export function ProjectCanvas({
 						selected={selected}
 						entered={entered}
 						picked={picked}
+						preview={preview}
 						guides={guides}
 						marquee={marquee}
 						shellRadius={shellRadius}
@@ -1826,9 +1951,9 @@ export function ProjectCanvas({
 							setMenu(null);
 						}}
 						onOpenEditor={() => {
-							const pick = pickedRef.current;
+							const pick = pickedRef.current.find((candidate) => candidate.frame === menu.frame);
 							openEditorFor(
-								pick !== null && pick.frame === menu.frame
+								pick !== undefined
 									? editorTarget(pick, framePageOf(pick.frame))
 									: { path: frameSourcePath(menu.frame, framePageOf(menu.frame)) },
 							);

--- a/src/ui/canvas/element-tree.test.ts
+++ b/src/ui/canvas/element-tree.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { buildTreeRows, revealKeys, rowSelectors, type TreeRow, visibleRows } from "./element-tree";
+import type { RawTreeNode } from "./protocol";
+
+/**
+ * The sidebar tree's view of a frame (#37): the raw DOM walk read through its
+ * stamps — same-stamp siblings collapse into one call-site row with [n]
+ * instances, a stamp-file change inserts a boundary row marking the edit
+ * cliff, and unstamped DOM inherits its parent's group.
+ */
+
+const FRAME_FILE = "frames/cart/frame.tsx";
+
+function node(partial: Partial<RawTreeNode> & { tag: string; selector: string }): RawTreeNode {
+	return { source: null, text: "", children: [], ...partial };
+}
+
+const cartTree: RawTreeNode[] = [
+	node({
+		tag: "main",
+		selector: "main",
+		source: "frames/cart/frame.tsx:3:3",
+		children: [
+			node({ tag: "h1", selector: "main > h1", source: "frames/cart/frame.tsx:5:4", text: "Din varukorg" }),
+			node({
+				tag: "ul",
+				selector: "main > ul",
+				source: "frames/cart/frame.tsx:8:4",
+				children: [
+					node({
+						tag: "li",
+						selector: "main > ul > li:nth-of-type(1)",
+						source: "frames/cart/frame.tsx:10:5",
+						text: "1 × Cortado",
+					}),
+					node({
+						tag: "li",
+						selector: "main > ul > li:nth-of-type(2)",
+						source: "frames/cart/frame.tsx:10:5",
+						text: "1 × Flat white",
+					}),
+				],
+			}),
+			node({
+				tag: "button",
+				selector: "main > button",
+				source: "shared/ui/button.tsx:5:2",
+				children: [
+					node({
+						tag: "span",
+						selector: "main > button > span",
+						source: "frames/cart/frame.tsx:12:6",
+						text: "Betala",
+					}),
+				],
+			}),
+			node({ tag: "aside", selector: "main > aside", source: null, text: "toast" }),
+		],
+	}),
+];
+
+describe("buildTreeRows", () => {
+	it("collapses same-stamp siblings into one call-site row with [n] instances", () => {
+		const rows = buildTreeRows(cartTree, FRAME_FILE);
+		const main = rows[0] as TreeRow & { children: TreeRow[] };
+		const ul = main.children[1] as TreeRow & { children: TreeRow[] };
+
+		expect(ul.children).toHaveLength(1);
+		const callsite = ul.children[0];
+		expect(callsite).toMatchObject({
+			kind: "callsite",
+			source: "frames/cart/frame.tsx:10:5",
+			tag: "li",
+			count: 2,
+		});
+		expect((callsite as { children: TreeRow[] }).children.map((row) => row)).toMatchObject([
+			{ kind: "instance", index: 0, selector: "main > ul > li:nth-of-type(1)", label: "1 × Cortado" },
+			{ kind: "instance", index: 1, selector: "main > ul > li:nth-of-type(2)", label: "1 × Flat white" },
+		]);
+	});
+
+	it("inserts a boundary row where the stamp file changes, nesting back on return", () => {
+		const rows = buildTreeRows(cartTree, FRAME_FILE);
+		const main = rows[0] as TreeRow & { children: TreeRow[] };
+
+		const boundary = main.children[2];
+		expect(boundary).toMatchObject({ kind: "boundary", file: "shared/ui/button.tsx", basename: "button.tsx" });
+		const button = (boundary as { children: TreeRow[] }).children[0];
+		expect(button).toMatchObject({ kind: "element", tag: "button", selector: "main > button" });
+		// the children prop renders frame-authored DOM inside the component: a
+		// boundary back to the frame's own file marks the return over the cliff
+		const back = (button as { children: TreeRow[] }).children[0];
+		expect(back).toMatchObject({ kind: "boundary", file: FRAME_FILE, basename: "frame.tsx" });
+		expect((back as { children: TreeRow[] }).children[0]).toMatchObject({
+			kind: "element",
+			tag: "span",
+			label: "Betala",
+		});
+	});
+
+	it("keeps unstamped DOM in its parent's group — no boundary, no stamp", () => {
+		const rows = buildTreeRows(cartTree, FRAME_FILE);
+		const main = rows[0] as TreeRow & { children: TreeRow[] };
+
+		expect(main.children[3]).toMatchObject({ kind: "element", tag: "aside", label: "toast", source: null });
+	});
+
+	it("labels an element by its own text and leaves a textless one to its tag", () => {
+		const rows = buildTreeRows(cartTree, FRAME_FILE);
+		const main = rows[0] as TreeRow & { children: TreeRow[] };
+
+		expect(main).toMatchObject({ kind: "element", tag: "main", label: "" });
+		expect(main.children[0]).toMatchObject({ kind: "element", tag: "h1", label: "Din varukorg" });
+	});
+});
+
+describe("visibleRows", () => {
+	it("flattens only through expanded rows, top level always visible", () => {
+		const rows = buildTreeRows(cartTree, FRAME_FILE);
+		const main = rows[0] as TreeRow;
+
+		expect(visibleRows(rows, new Set()).map((row) => row.key)).toEqual([main.key]);
+
+		const ul = (main as { children: TreeRow[] }).children[1] as TreeRow;
+		const expanded = new Set([main.key, ul.key]);
+		const keys = visibleRows(rows, expanded).map((row) => row.kind);
+		// main, h1, ul, callsite (instances stay folded), boundary, aside
+		expect(keys).toEqual(["element", "element", "element", "callsite", "boundary", "element"]);
+	});
+});
+
+describe("revealKeys", () => {
+	it("answers every ancestor row to expand, boundary and call-site rows included", () => {
+		const rows = buildTreeRows(cartTree, FRAME_FILE);
+		const main = rows[0] as TreeRow & { children: TreeRow[] };
+		const ul = main.children[1] as TreeRow & { children: TreeRow[] };
+		const callsite = ul.children[0] as TreeRow;
+
+		const reveal = revealKeys(rows, "main > ul > li:nth-of-type(2)");
+		expect(reveal?.ancestors).toEqual([main.key, ul.key, callsite.key]);
+
+		const boundary = main.children[2] as TreeRow & { children: TreeRow[] };
+		const button = boundary.children[0] as TreeRow;
+		const inButton = revealKeys(rows, "main > button > span");
+		expect(inButton?.ancestors).toEqual([
+			main.key,
+			boundary.key,
+			button.key,
+			(button as { children: TreeRow[] }).children[0]?.key,
+		]);
+
+		expect(revealKeys(rows, "main > ghost")).toBeUndefined();
+	});
+});
+
+describe("rowSelectors", () => {
+	it("answers the selectors a row stands for", () => {
+		const rows = buildTreeRows(cartTree, FRAME_FILE);
+		const main = rows[0] as TreeRow & { children: TreeRow[] };
+		const ul = main.children[1] as TreeRow & { children: TreeRow[] };
+		const callsite = ul.children[0] as TreeRow;
+		const boundary = main.children[2] as TreeRow;
+
+		expect(rowSelectors(main)).toEqual(["main"]);
+		expect(rowSelectors(callsite)).toEqual(["main > ul > li:nth-of-type(1)", "main > ul > li:nth-of-type(2)"]);
+		expect(rowSelectors(boundary)).toEqual([]);
+	});
+});

--- a/src/ui/canvas/element-tree.ts
+++ b/src/ui/canvas/element-tree.ts
@@ -1,0 +1,154 @@
+import { parseStampRef, type RawTreeNode } from "./protocol";
+
+/**
+ * The sidebar tree's view-model (#37): the frame's raw DOM walk read through
+ * its compile-time stamps. Same-stamp siblings collapse into one call-site
+ * row (`cart.map(…)`) with [n] instance children; where the stamp file
+ * changes — components stamp where they are authored — a boundary row marks
+ * the edit cliff, nesting back when children props return over it; unstamped
+ * DOM inherits its parent's group. Rows are selection context only: the tree
+ * never writes source.
+ */
+
+interface RowBase {
+	key: string;
+	children: TreeRow[];
+}
+
+export type TreeRow =
+	| (RowBase & { kind: "element"; selector: string; tag: string; label: string; source: string | null })
+	| (RowBase & { kind: "callsite"; source: string; tag: string; count: number })
+	| (RowBase & { kind: "instance"; index: number; selector: string; tag: string; label: string; source: string })
+	| (RowBase & { kind: "boundary"; file: string; basename: string });
+
+export function buildTreeRows(roots: readonly RawTreeNode[], frameFile: string): TreeRow[] {
+	return buildList(roots, frameFile);
+}
+
+function buildList(nodes: readonly RawTreeNode[], contextFile: string): TreeRow[] {
+	// siblings sharing a stamp collapse into one call-site row at the first
+	// occurrence — adjacency not required: interleaved map output still groups
+	const counts = new Map<string, number>();
+	for (const node of nodes) {
+		if (node.source !== null) counts.set(node.source, (counts.get(node.source) ?? 0) + 1);
+	}
+
+	const built: { row: TreeRow; file: string }[] = [];
+	const consumed = new Set<string>();
+	for (const node of nodes) {
+		const source = node.source;
+		const file = fileOf(source) ?? contextFile;
+		if (source !== null && (counts.get(source) ?? 0) > 1) {
+			if (consumed.has(source)) continue;
+			consumed.add(source);
+			const members = nodes.filter((sibling) => sibling.source === source);
+			const row: TreeRow = {
+				kind: "callsite",
+				key: `c:${source}@${node.selector}`,
+				source,
+				tag: node.tag,
+				count: members.length,
+				children: members.map((member, index) => ({
+					kind: "instance",
+					key: `i:${member.selector}`,
+					index,
+					selector: member.selector,
+					tag: member.tag,
+					label: member.text,
+					source,
+					children: buildList(member.children, file),
+				})),
+			};
+			built.push({ row, file });
+			continue;
+		}
+		const row: TreeRow = {
+			kind: "element",
+			key: `e:${node.selector}`,
+			selector: node.selector,
+			tag: node.tag,
+			label: node.text,
+			source: node.source,
+			children: buildList(node.children, file),
+		};
+		built.push({ row, file });
+	}
+
+	// a run of rows from another file goes behind one boundary row — the edit
+	// cliff: selection paths inside it point at the shared file
+	const out: TreeRow[] = [];
+	let index = 0;
+	while (index < built.length) {
+		const entry = built[index];
+		if (entry === undefined) break;
+		if (entry.file === contextFile) {
+			out.push(entry.row);
+			index++;
+			continue;
+		}
+		const run: TreeRow[] = [];
+		const file = entry.file;
+		while (index < built.length && built[index]?.file === file) {
+			const member = built[index];
+			if (member !== undefined) run.push(member.row);
+			index++;
+		}
+		out.push({
+			kind: "boundary",
+			key: `b:${file}@${run[0]?.key ?? String(index)}`,
+			file,
+			basename: file.split("/").pop() ?? file,
+			children: run,
+		});
+	}
+	return out;
+}
+
+/** "frames/cart/frame.tsx:10:5" → the file part; undefined for no stamp. */
+function fileOf(source: string | null): string | undefined {
+	return parseStampRef(source)?.rel;
+}
+
+/** The rows on screen, visual order: children appear under expanded rows only. */
+export function visibleRows(rows: readonly TreeRow[], expanded: ReadonlySet<string>): TreeRow[] {
+	const out: TreeRow[] = [];
+	const walk = (list: readonly TreeRow[]) => {
+		for (const row of list) {
+			out.push(row);
+			if (expanded.has(row.key)) walk(row.children);
+		}
+	};
+	walk(rows);
+	return out;
+}
+
+/** The row for a selector and every ancestor row that must expand to show it. */
+export function revealKeys(
+	rows: readonly TreeRow[],
+	selector: string,
+): { ancestors: string[]; key: string } | undefined {
+	const walk = (list: readonly TreeRow[], path: string[]): { ancestors: string[]; key: string } | undefined => {
+		for (const row of list) {
+			if ((row.kind === "element" || row.kind === "instance") && row.selector === selector) {
+				return { ancestors: path, key: row.key };
+			}
+			const found = walk(row.children, [...path, row.key]);
+			if (found !== undefined) return found;
+		}
+		return undefined;
+	};
+	return walk(rows, []);
+}
+
+/** The elements a row stands for when selected — a boundary stands for none. */
+export function rowSelectors(row: TreeRow): string[] {
+	switch (row.kind) {
+		case "element":
+		case "instance":
+			return [row.selector];
+		case "callsite":
+			return row.children.flatMap((child) => (child.kind === "instance" ? [child.selector] : []));
+		case "boundary":
+			return [];
+	}
+}

--- a/src/ui/canvas/lifecycle.test.ts
+++ b/src/ui/canvas/lifecycle.test.ts
@@ -43,6 +43,7 @@ function sweeper() {
 			mode: "live",
 			entered: null,
 			selected: null,
+			wakeRequested: new Set(),
 			states,
 			ready: new Set(frames.map((f) => f.name)),
 			capturing: new Set(),
@@ -146,6 +147,26 @@ describe("intent", () => {
 		const first = sweep([frame("off", 5000, 5000)], { selected: "off" });
 		expect(first.states).toEqual({ off: "warm" });
 	});
+
+	it("admits a wake-requested frame behind selected, ahead of the visible tiers (#37)", () => {
+		const { sweep } = sweeper();
+
+		// an offscreen expand must not wait behind five visible mounts
+		const first = sweep([...inView, frame("off", 5000, 5000)], { wakeRequested: new Set(["off"]) });
+		expect(first.states.off).toBe("warm");
+
+		// selected still outranks it: with three slots, the last request waits
+		const contended = sweeper().sweep(
+			[frame("s", 5000, 5000), frame("r1", 7000, 5000), frame("r2", 9000, 5000), frame("r3", 11000, 5000)],
+			{ selected: "s", wakeRequested: new Set(["r1", "r2", "r3"]) },
+		);
+		expect(contended.states.s).toBe("warm");
+		expect(
+			Object.entries(contended.states)
+				.filter(([, state]) => state === "hibernated")
+				.map(([name]) => name),
+		).toHaveLength(1);
+	});
 });
 
 describe("warm pool", () => {
@@ -225,6 +246,21 @@ describe("warm pool", () => {
 		expect(held.states.f0).toBe("warm");
 
 		// deselection releases it to normal pool policy
+		const released = s.sweep(frames, { camera: parked });
+		expect(released.exitCaptures).toEqual(["f0"]);
+	});
+
+	it("never evicts a wake-requested frame while the request stands (#37)", () => {
+		const frames = strip(WARM_POOL_CAP + 1);
+		const s = sweeper();
+		tour(s, frames);
+
+		// f0 is the oldest-seen, but an expanded tree row keeps it real
+		const held = s.sweep(frames, { camera: parked, wakeRequested: new Set(["f0"]) });
+		expect(held.exitCaptures).toEqual([]);
+		expect(held.states.f0).toBe("warm");
+
+		// collapsing the row releases it to normal pool policy
 		const released = s.sweep(frames, { camera: parked });
 		expect(released.exitCaptures).toEqual(["f0"]);
 	});

--- a/src/ui/canvas/lifecycle.ts
+++ b/src/ui/canvas/lifecycle.ts
@@ -12,12 +12,12 @@ import { captureMessage } from "./protocol";
  * Hibernation's payoff is memory, never CPU: only pool overflow demotes a
  * frame to its still, oldest-seen first, html frames taking a goodbye
  * self-capture on the way out. Every mount drains through the wake queue —
- * entered immediately, selected next, then nearest the viewport center, a
- * few per sweep — so no burst site (zoom wake, design flip, page entry) can
- * land every mount in one commit. Design mode: real DOM everywhere, time
- * stopped, never evicted. Hibernation is automatic engine lifecycle, never a
- * user mode; double-click boots a hibernated frame fresh — reset-on-return
- * is a feature.
+ * entered immediately, selected next, then wake-requested rows (#37), then
+ * nearest the viewport center, a few per sweep — so no burst site (zoom
+ * wake, design flip, page entry) can land every mount in one commit. Design
+ * mode: real DOM everywhere, time stopped, never evicted. Hibernation is
+ * automatic engine lifecycle, never a user mode; double-click boots a
+ * hibernated frame fresh — reset-on-return is a feature.
  */
 
 export type FrameState = "live" | "warm" | "hibernated";
@@ -67,6 +67,8 @@ export interface SweepInput {
 	mode: CanvasMode;
 	entered: string | null;
 	selected: string | null;
+	/** Frames whose tree row is expanded (#37): expand is attention — wake them. */
+	wakeRequested: ReadonlySet<string>;
 	states: Readonly<Record<string, FrameState>>;
 	/** Frames whose boot has reported loaded — the ones a capture can reach. */
 	ready: ReadonlySet<string>;
@@ -94,6 +96,7 @@ export function sweepLifecycle(model: LifecycleModel, input: SweepInput): SweepR
 		mode,
 		entered,
 		selected,
+		wakeRequested,
 		states,
 		ready,
 		capturing,
@@ -149,8 +152,9 @@ export function sweepLifecycle(model: LifecycleModel, input: SweepInput): SweepR
 		} else {
 			target = "hibernated";
 			// first click pre-boots (#8): a selected frame mounts hidden so the
-			// double-click that follows reveals an already-running frame
-			wakeTo = usable ? "live" : selected === frame.name ? "warm" : null;
+			// double-click that follows reveals an already-running frame — and an
+			// expanded tree row asks the same way (#37)
+			wakeTo = usable ? "live" : selected === frame.name || wakeRequested.has(frame.name) ? "warm" : null;
 		}
 
 		const entry: Entry = { frame, current, usable, target };
@@ -158,7 +162,16 @@ export function sweepLifecycle(model: LifecycleModel, input: SweepInput): SweepR
 		if (wakeTo !== null) {
 			const cx = frame.x + frame.w / 2 - center.x;
 			const cy = frame.y + frame.h / 2 - center.y;
-			const tier = selected === frame.name ? 0 : intersects(strict, frame) ? 1 : onScreen ? 2 : 3;
+			const tier =
+				selected === frame.name
+					? 0
+					: wakeRequested.has(frame.name)
+						? 1
+						: intersects(strict, frame)
+							? 2
+							: onScreen
+								? 3
+								: 4;
 			waiting.push({ entry, wakeTo, tier, dist: cx * cx + cy * cy });
 		}
 	}
@@ -180,9 +193,15 @@ export function sweepLifecycle(model: LifecycleModel, input: SweepInput): SweepR
 		}
 		// the warm pool: only overflow hibernates, oldest-seen first — live frames
 		// never count, the selected frame is pre-boot intent (evicting it would
-		// only re-queue it), and a mid-goodbye frame is already on its way out
+		// only re-queue it), a wake-requested frame is watched intent (#37), and
+		// a mid-goodbye frame is already on its way out
 		const pool = entries.filter(
-			(e) => e.target === "warm" && !e.usable && e.frame.name !== selected && !model.exitPending.has(e.frame.name),
+			(e) =>
+				e.target === "warm" &&
+				!e.usable &&
+				e.frame.name !== selected &&
+				!wakeRequested.has(e.frame.name) &&
+				!model.exitPending.has(e.frame.name),
 		);
 		const overflow = pool.length - WARM_POOL_CAP;
 		if (overflow > 0) {
@@ -237,12 +256,14 @@ export interface LifecycleDeps {
 	mode: CanvasMode;
 	entered: string | null;
 	selected: string | null;
+	/** Frames whose tree row is expanded (#37) — wake and keep them real. */
+	wakeRequested: ReadonlySet<string>;
 	hasThumb: (frame: string) => boolean;
 	onShot: (frame: string, dataUrl: string) => void;
 }
 
 export function useFrameLifecycle(deps: LifecycleDeps) {
-	const { framesRef, cameraRef, viewportRef, mode, entered, selected, hasThumb, onShot } = deps;
+	const { framesRef, cameraRef, viewportRef, mode, entered, selected, wakeRequested, hasThumb, onShot } = deps;
 
 	const [states, setStates] = useState<Record<string, FrameState>>({});
 	const [ready, setReady] = useState<ReadonlySet<string>>(new Set<string>());
@@ -256,6 +277,8 @@ export function useFrameLifecycle(deps: LifecycleDeps) {
 	enteredRef.current = entered;
 	const selectedRef = useRef(selected);
 	selectedRef.current = selected;
+	const wakeRequestedRef = useRef(wakeRequested);
+	wakeRequestedRef.current = wakeRequested;
 	const hasThumbRef = useRef(hasThumb);
 	hasThumbRef.current = hasThumb;
 	const onShotRef = useRef(onShot);
@@ -328,6 +351,7 @@ export function useFrameLifecycle(deps: LifecycleDeps) {
 			mode: modeRef.current,
 			entered: enteredRef.current,
 			selected: selectedRef.current,
+			wakeRequested: wakeRequestedRef.current,
 			states: statesRef.current,
 			ready: readyRef.current,
 			capturing: new Set(captureWaiters.current.keys()),
@@ -346,6 +370,12 @@ export function useFrameLifecycle(deps: LifecycleDeps) {
 		modeRef.current = mode;
 		compute();
 	}, [mode, compute]);
+
+	// so does an expand: the wake must start now, not one sweep late (#37)
+	useEffect(() => {
+		wakeRequestedRef.current = wakeRequested;
+		compute();
+	}, [wakeRequested, compute]);
 
 	useEffect(() => {
 		const sweep = setInterval(compute, SWEEP_MS);

--- a/src/ui/canvas/overlays.tsx
+++ b/src/ui/canvas/overlays.tsx
@@ -2,7 +2,7 @@ import { cellsForPx } from "../../term/cells";
 import type { Camera, ProjectedFrame } from "../api";
 import type { Box } from "./camera";
 import { frameSourcePath, frameSourceRel, pageOf } from "./pages";
-import type { PickedHit } from "./protocol";
+import { type PickedHit, parseStampRef } from "./protocol";
 
 /**
  * Screen-space selection furniture (#23), drawn over the transformed field so
@@ -17,6 +17,9 @@ import type { PickedHit } from "./protocol";
 export interface PickedSelection extends PickedHit {
 	frame: string;
 }
+
+/** The (frame, selector) pair as one identity — picks match on nothing else. */
+export const pickKey = (frame: string, selector: string): string => `${frame}\0${selector}`;
 
 /** The would-be click target under the cursor (#37) — outlined, never selected. */
 export interface ElementPreview {
@@ -85,6 +88,12 @@ export function SelectionOverlay({
 		w: box.w * k,
 		h: box.h * k,
 	});
+	/** A frame-local element rect on screen — undefined when the frame is gone. */
+	const elementBox = (name: string, rect: { x: number; y: number; w: number; h: number }): Box | undefined => {
+		const frame = frames.find((f) => f.name === name);
+		if (frame === undefined) return undefined;
+		return screenRect({ x: frame.x + rect.x, y: frame.y + rect.y, w: rect.w, h: rect.h });
+	};
 	const ringRadius = Math.min(12, shellRadius * k) + 2;
 
 	const ringed = [...new Set(entered === null ? selected : [...selected, entered])];
@@ -189,51 +198,16 @@ export function SelectionOverlay({
 				})()}
 
 			{picked.map((pick) => {
-				const frame = frames.find((f) => f.name === pick.frame);
-				if (frame === undefined) return null;
-				const rect = screenRect({
-					x: frame.x + pick.rect.x,
-					y: frame.y + pick.rect.y,
-					w: pick.rect.w,
-					h: pick.rect.h,
-				});
-				return (
-					<div
-						key={`pick-${pick.frame}-${pick.selector}`}
-						className="absolute border border-thread"
-						style={{
-							left: rect.x - 2,
-							top: rect.y - 2,
-							width: rect.w + 4,
-							height: rect.h + 4,
-							borderRadius: pick.radius * k + 2,
-						}}
-					/>
-				);
+				const box = elementBox(pick.frame, pick.rect);
+				if (box === undefined) return null;
+				return <ElementOutline key={pickKey(pick.frame, pick.selector)} box={box} radius={pick.radius * k} />;
 			})}
 
 			{previewShown !== null &&
 				(() => {
-					const frame = frames.find((f) => f.name === previewShown.frame);
-					if (frame === undefined) return null;
-					const rect = screenRect({
-						x: frame.x + previewShown.rect.x,
-						y: frame.y + previewShown.rect.y,
-						w: previewShown.rect.w,
-						h: previewShown.rect.h,
-					});
-					return (
-						<div
-							className="absolute border border-thread opacity-50"
-							style={{
-								left: rect.x - 2,
-								top: rect.y - 2,
-								width: rect.w + 4,
-								height: rect.h + 4,
-								borderRadius: previewShown.radius * k + 2,
-							}}
-						/>
-					);
+					const box = elementBox(previewShown.frame, previewShown.rect);
+					if (box === undefined) return null;
+					return <ElementOutline box={box} radius={previewShown.radius * k} faded />;
 				})()}
 
 			{[...pickedByFrame.entries()].map(([name, picks]) => {
@@ -275,9 +249,25 @@ export function SelectionOverlay({
 	);
 }
 
+/** The element outline: 1px thread at 2px offset, no handles — faded previews. */
+function ElementOutline({ box, radius, faded }: { box: Box; radius: number; faded?: boolean }) {
+	return (
+		<div
+			className={`absolute border border-thread ${faded === true ? "opacity-50" : ""}`}
+			style={{
+				left: box.x - 2,
+				top: box.y - 2,
+				width: box.w + 4,
+				height: box.h + 4,
+				borderRadius: radius + 2,
+			}}
+		/>
+	);
+}
+
 /** "frames/cart/frame.tsx:38" — the stamp minus its column, or the frame file. */
 function chipLabel(picked: PickedSelection, page: string): string {
-	const stamp = parseStamp(picked);
+	const stamp = parseStampRef(picked.source);
 	if (stamp === undefined) return frameSourceRel(picked.frame, page);
 	return `${stamp.rel}:${stamp.line}`;
 }
@@ -285,13 +275,7 @@ function chipLabel(picked: PickedSelection, page: string): string {
 /** The editor target off the selection (#7: path:line from the payload). The
  * stampless fallback needs the frame's page — the folder moved with it (#39). */
 export function editorTarget(picked: PickedSelection, page: string): { path: string; line?: number } {
-	const stamp = parseStamp(picked);
+	const stamp = parseStampRef(picked.source);
 	if (stamp === undefined) return { path: frameSourcePath(picked.frame, page) };
 	return { path: `design/${stamp.rel}`, line: stamp.line };
-}
-
-function parseStamp(picked: PickedSelection): { rel: string; line: number } | undefined {
-	const [, rel, line] = picked.source?.match(/^(.+):(\d+):(\d+)$/) ?? [];
-	if (rel === undefined || line === undefined) return undefined;
-	return { rel, line: Number.parseInt(line, 10) };
 }

--- a/src/ui/canvas/overlays.tsx
+++ b/src/ui/canvas/overlays.tsx
@@ -1,7 +1,7 @@
 import { cellsForPx } from "../../term/cells";
 import type { Camera, ProjectedFrame } from "../api";
 import type { Box } from "./camera";
-import { frameSourcePath, frameSourceRel, pageOf, ROOT_PAGE } from "./pages";
+import { frameSourcePath, frameSourceRel, pageOf } from "./pages";
 import type { PickedHit } from "./protocol";
 
 /**
@@ -16,6 +16,14 @@ import type { PickedHit } from "./protocol";
 
 export interface PickedSelection extends PickedHit {
 	frame: string;
+}
+
+/** The would-be click target under the cursor (#37) — outlined, never selected. */
+export interface ElementPreview {
+	frame: string;
+	selector: string;
+	rect: { x: number; y: number; w: number; h: number };
+	radius: number;
 }
 
 export interface Guides {
@@ -52,6 +60,7 @@ export function SelectionOverlay({
 	selected,
 	entered,
 	picked,
+	preview,
 	guides,
 	marquee,
 	shellRadius,
@@ -61,7 +70,8 @@ export function SelectionOverlay({
 	frames: ProjectedFrame[];
 	selected: readonly string[];
 	entered: string | null;
-	picked: PickedSelection | null;
+	picked: readonly PickedSelection[];
+	preview: ElementPreview | null;
 	guides: Guides;
 	/** Normalized screen-space rect while a marquee drag is live. */
 	marquee: Box | null;
@@ -79,8 +89,17 @@ export function SelectionOverlay({
 
 	const ringed = [...new Set(entered === null ? selected : [...selected, entered])];
 	const single = selected.length === 1 && entered === null ? frames.find((f) => f.name === selected[0]) : undefined;
-	const pickedFrame = picked === null ? undefined : frames.find((f) => f.name === picked.frame);
-	const pickedPage = pickedFrame === undefined ? ROOT_PAGE : pageOf(pickedFrame);
+	// one chip per frame holding picks: the first pick names the file, the rest count
+	const pickedByFrame = new Map<string, PickedSelection[]>();
+	for (const pick of picked) {
+		const held = pickedByFrame.get(pick.frame);
+		if (held === undefined) pickedByFrame.set(pick.frame, [pick]);
+		else held.push(pick);
+	}
+	const previewShown =
+		preview !== null && !picked.some((pick) => pick.frame === preview.frame && pick.selector === preview.selector)
+			? preview
+			: null;
 
 	return (
 		<div className="pointer-events-none absolute inset-0">
@@ -169,50 +188,82 @@ export function SelectionOverlay({
 					);
 				})()}
 
-			{picked !== null && pickedFrame !== undefined && (
-				<>
-					{(() => {
-						const rect = screenRect({
-							x: pickedFrame.x + picked.rect.x,
-							y: pickedFrame.y + picked.rect.y,
-							w: picked.rect.w,
-							h: picked.rect.h,
-						});
-						return (
-							<div
-								className="absolute border border-thread"
-								style={{
-									left: rect.x - 2,
-									top: rect.y - 2,
-									width: rect.w + 4,
-									height: rect.h + 4,
-									borderRadius: picked.radius * k + 2,
-								}}
-							/>
-						);
-					})()}
-					{(() => {
-						const rect = screenRect(pickedFrame);
-						return (
-							<div
-								className="pointer-events-auto absolute flex items-center gap-1.5 rounded-xs border border-border-raised bg-raised px-2 py-unit"
-								style={{ left: rect.x, top: rect.y + rect.h + 12 }}
-								onPointerDown={(event) => event.stopPropagation()}
+			{picked.map((pick) => {
+				const frame = frames.find((f) => f.name === pick.frame);
+				if (frame === undefined) return null;
+				const rect = screenRect({
+					x: frame.x + pick.rect.x,
+					y: frame.y + pick.rect.y,
+					w: pick.rect.w,
+					h: pick.rect.h,
+				});
+				return (
+					<div
+						key={`pick-${pick.frame}-${pick.selector}`}
+						className="absolute border border-thread"
+						style={{
+							left: rect.x - 2,
+							top: rect.y - 2,
+							width: rect.w + 4,
+							height: rect.h + 4,
+							borderRadius: pick.radius * k + 2,
+						}}
+					/>
+				);
+			})}
+
+			{previewShown !== null &&
+				(() => {
+					const frame = frames.find((f) => f.name === previewShown.frame);
+					if (frame === undefined) return null;
+					const rect = screenRect({
+						x: frame.x + previewShown.rect.x,
+						y: frame.y + previewShown.rect.y,
+						w: previewShown.rect.w,
+						h: previewShown.rect.h,
+					});
+					return (
+						<div
+							className="absolute border border-thread opacity-50"
+							style={{
+								left: rect.x - 2,
+								top: rect.y - 2,
+								width: rect.w + 4,
+								height: rect.h + 4,
+								borderRadius: previewShown.radius * k + 2,
+							}}
+						/>
+					);
+				})()}
+
+			{[...pickedByFrame.entries()].map(([name, picks]) => {
+				const frame = frames.find((f) => f.name === name);
+				const first = picks[0];
+				if (frame === undefined || first === undefined) return null;
+				const rect = screenRect(frame);
+				return (
+					<div
+						key={`chip-${name}`}
+						className="pointer-events-auto absolute flex items-center gap-1.5 rounded-xs border border-border-raised bg-raised px-2 py-unit"
+						style={{ left: rect.x, top: rect.y + rect.h + 12 }}
+						onPointerDown={(event) => event.stopPropagation()}
+					>
+						<span className="font-mono text-2xs text-muted leading-3">{chipLabel(first, pageOf(frame))}</span>
+						<span className="font-mono text-2xs text-muted leading-3">·</span>
+						{picks.length > 1 ? (
+							<span className="font-mono text-2xs text-text leading-3">{picks.length} elements</span>
+						) : (
+							<button
+								type="button"
+								className="font-mono text-2xs text-text leading-3 hover:text-thread"
+								onClick={() => onOpenEditor(first)}
 							>
-								<span className="font-mono text-2xs text-muted leading-3">{chipLabel(picked, pickedPage)}</span>
-								<span className="font-mono text-2xs text-muted leading-3">·</span>
-								<button
-									type="button"
-									className="font-mono text-2xs text-text leading-3 hover:text-thread"
-									onClick={() => onOpenEditor(picked)}
-								>
-									Open in editor
-								</button>
-							</div>
-						);
-					})()}
-				</>
-			)}
+								Open in editor
+							</button>
+						)}
+					</div>
+				);
+			})}
 
 			{marquee !== null && (
 				<div

--- a/src/ui/canvas/protocol.test.ts
+++ b/src/ui/canvas/protocol.test.ts
@@ -57,3 +57,26 @@ describe("site boxes protocol (#34)", () => {
 		expect(parseFrameMessage({ spool: "site-boxes", frame: "cart", boxes: {} })).toBeUndefined();
 	});
 });
+
+describe("element tree protocol (#37)", () => {
+	it("accepts a shim's tree answer and rejects a shapeless one", () => {
+		const answer = {
+			spool: "tree",
+			frame: "cart",
+			id: 5,
+			roots: [{ tag: "main", selector: "main", source: "frames/cart/frame.tsx:3:3", text: "", children: [] }],
+		};
+
+		expect(parseFrameMessage(answer)).toEqual(answer);
+		expect(parseFrameMessage({ spool: "tree", frame: "cart", id: 5 })).toBeUndefined();
+		expect(parseFrameMessage({ spool: "tree", frame: "cart", roots: [] })).toBeUndefined();
+	});
+
+	it("accepts a shim's describe answer and rejects a shapeless one", () => {
+		const answer = { spool: "described", frame: "cart", id: 6, chains: [[], []] };
+
+		expect(parseFrameMessage(answer)).toEqual(answer);
+		expect(parseFrameMessage({ spool: "described", frame: "cart", id: 6 })).toBeUndefined();
+		expect(parseFrameMessage({ spool: "described", frame: "cart", chains: [] })).toBeUndefined();
+	});
+});

--- a/src/ui/canvas/protocol.ts
+++ b/src/ui/canvas/protocol.ts
@@ -24,6 +24,30 @@ export interface PickedHit {
 	generated: boolean;
 }
 
+/** A stamp taken apart: "frames/cart/frame.tsx:10:5" → rel, line, col. */
+export interface StampRef {
+	rel: string;
+	line: number;
+	col: number;
+}
+
+export function parseStampRef(source: string | null | undefined): StampRef | undefined {
+	const [, rel, line, col] = source?.match(/^(.+):(\d+):(\d+)$/) ?? [];
+	if (rel === undefined || line === undefined || col === undefined) return undefined;
+	return { rel, line: Number.parseInt(line, 10), col: Number.parseInt(col, 10) };
+}
+
+/** One element of a frame's live DOM as the tree walk serialized it (#37). */
+export interface RawTreeNode {
+	tag: string;
+	selector: string;
+	/** The element's own stamp — null for JS-created DOM, which inherits its parent's group. */
+	source: string | null;
+	/** Direct text children, collapsed and capped — the row label when non-empty. */
+	text: string;
+	children: RawTreeNode[];
+}
+
 interface FrameWheelZoomMessage {
 	spool: "zoom";
 	frame: string;
@@ -59,6 +83,8 @@ export type FrameMessage =
 	| { spool: "key"; frame: string; key: string }
 	| FrameZoomMessage
 	| { spool: "picked"; frame: string; id: number; chain: PickedHit[] }
+	| { spool: "tree"; frame: string; id: number; roots: RawTreeNode[] }
+	| { spool: "described"; frame: string; id: number; chains: PickedHit[][] }
 	| { spool: "site-boxes"; frame: string; id: number; boxes: SiteBoxes }
 	| { spool: "external"; frame: string; href: string }
 	| { spool: "go"; frame: string; target: string; session?: SessionRecord }
@@ -89,6 +115,10 @@ export function parseFrameMessage(data: unknown): FrameMessage | undefined {
 				: undefined;
 		case "picked":
 			return Array.isArray(m.chain) && typeof m.id === "number" ? (m as unknown as FrameMessage) : undefined;
+		case "tree":
+			return Array.isArray(m.roots) && typeof m.id === "number" ? (m as unknown as FrameMessage) : undefined;
+		case "described":
+			return Array.isArray(m.chains) && typeof m.id === "number" ? (m as unknown as FrameMessage) : undefined;
 		case "site-boxes":
 			return typeof m.boxes === "object" && m.boxes !== null && typeof m.id === "number"
 				? (m as unknown as FrameMessage)
@@ -118,5 +148,8 @@ function webHref(value: unknown): value is string {
 export const freezeMessage = (on: boolean) => ({ spool: "freeze", on }) as const;
 export const captureMessage = { spool: "capture" } as const;
 export const pickMessage = (x: number, y: number, id: number) => ({ spool: "pick", x, y, id }) as const;
+// "tree?" asks, "tree" answers — distinct kinds, so a reply can never read as a request
+export const treeMessage = (id: number) => ({ spool: "tree?", id }) as const;
+export const describeMessage = (selectors: string[], id: number) => ({ spool: "describe", selectors, id }) as const;
 export const sessionReply = (record: SessionRecord | null) => ({ spool: "session", record }) as const;
 export const sitesMessage = (sites: SiteAnchor[], id: number) => ({ spool: "sites", sites, id }) as const;

--- a/src/ui/canvas/sidebar.tsx
+++ b/src/ui/canvas/sidebar.tsx
@@ -1,14 +1,20 @@
-import { useRef, useState } from "react";
-import type { ProjectedFrame } from "../api";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { CanvasMode, ProjectedFrame } from "../api";
+import type { TreeRow } from "./element-tree";
+import { rowSelectors } from "./element-tree";
+import { type PickedSelection, pickKey } from "./overlays";
 import { pageLabel, pageList } from "./pages";
 
 /**
- * The frames sidebar (#39), to the settled file-tree design: one collapsible
- * left panel — the pages list above the active page's frame list, rows in the
- * frame-row idiom. The panel is a navigator over the projection: rows select
- * and switch, they never author. Dragging the edge resizes; past the snap
- * threshold it collapses to the rail. The per-frame element tree layers in
- * later under #37.
+ * The frames sidebar (#39) with the element tree layered in (#37), to the
+ * settled file-tree design: one collapsible left panel — pages above the
+ * active page's frame list, each frame row expandable into its element tree
+ * in design mode. The panel is a navigator over the projection and the live
+ * DOM: rows select, switch, and jump; they never author. One grammar across
+ * every list: shift ranges over visible rows, ⌘/Ctrl toggles, a single click
+ * selects and never moves the camera — double-click flies (frames) or opens
+ * the editor (elements). Dragging the edge resizes; past the snap threshold
+ * it collapses to the rail.
  */
 
 const PANEL_WIDTH = 248;
@@ -18,13 +24,38 @@ const MAX_WIDTH = 320;
 const SNAP_BELOW = 144;
 const COLLAPSED_BELOW = 72;
 
+const ROW_INDENT = 16;
+
+export interface SelectModifiers {
+	shift: boolean;
+	toggle: boolean;
+}
+
+const modifiersOf = (event: React.MouseEvent): SelectModifiers => ({
+	shift: event.shiftKey,
+	toggle: event.metaKey || event.ctrlKey,
+});
+
 export function CanvasSidebar({
 	pages,
 	activePage,
 	frames,
 	selected,
+	mode,
+	picked,
+	rowsByFrame,
+	callSiteLabels,
+	expandedFrames,
+	expandedRows,
+	pendingWakes,
+	revealTarget,
 	onSwitchPage,
 	onSelectFrame,
+	onDoubleClickFrame,
+	onToggleFrame,
+	onSelectRow,
+	onDoubleClickRow,
+	onToggleRow,
 }: {
 	/** Named pages, sorted; the root page is implied and listed first. */
 	pages: readonly string[];
@@ -32,13 +63,38 @@ export function CanvasSidebar({
 	/** The active page's frames, projection order. */
 	frames: readonly ProjectedFrame[];
 	selected: readonly string[];
+	mode: CanvasMode;
+	picked: readonly PickedSelection[];
+	/** Each expanded frame's element tree, once its DOM has answered. */
+	rowsByFrame: Record<string, TreeRow[]>;
+	callSiteLabels: Record<string, string | null>;
+	expandedFrames: ReadonlySet<string>;
+	expandedRows: ReadonlySet<string>;
+	/** Expanded frames whose DOM has not answered yet — the quiet wake state. */
+	pendingWakes: ReadonlySet<string>;
+	/** The row key a canvas pick wants on screen. */
+	revealTarget: string | undefined;
 	onSwitchPage: (page: string) => void;
-	onSelectFrame: (name: string) => void;
+	onSelectFrame: (name: string, modifiers: SelectModifiers) => void;
+	onDoubleClickFrame: (name: string) => void;
+	onToggleFrame: (name: string) => void;
+	onSelectRow: (frame: string, row: TreeRow, modifiers: SelectModifiers) => void;
+	onDoubleClickRow: (frame: string, row: TreeRow) => void;
+	onToggleRow: (key: string) => void;
 }) {
 	const [width, setWidth] = useState(PANEL_WIDTH);
 	const [dragging, setDragging] = useState(false);
 	const drag = useRef<{ pointerId: number; startWidth: number; startX: number; latestWidth: number } | null>(null);
 	const collapsed = width <= COLLAPSED_BELOW;
+	const rowElements = useRef(new Map<string, HTMLElement>());
+
+	// selection sync (#37): the revealed row scrolls into view, never centered
+	useEffect(() => {
+		if (revealTarget === undefined) return;
+		rowElements.current.get(revealTarget)?.scrollIntoView({ block: "nearest" });
+	}, [revealTarget]);
+
+	const pickedKeys = useMemo(() => new Set(picked.map((pick) => pickKey(pick.frame, pick.selector))), [picked]);
 
 	function finishDrag(target: HTMLElement, pointerId: number) {
 		const current = drag.current;
@@ -115,21 +171,90 @@ export function CanvasSidebar({
 					<div className="min-h-0 flex-1 overflow-y-auto py-2">
 						{frames.map((frame) => {
 							const isSelected = selected.includes(frame.name);
+							const open = mode === "design" && expandedFrames.has(frame.name);
+							const rows = rowsByFrame[frame.name];
 							return (
-								<button
-									key={frame.name}
-									type="button"
-									aria-pressed={isSelected}
-									onClick={() => onSelectFrame(frame.name)}
-									className={`flex h-8 w-full min-w-0 items-center gap-2 px-3 text-left font-mono text-sm leading-sm hover:bg-surface ${
-										isSelected ? "text-text" : "text-muted"
-									}`}
-								>
-									<FrameIcon className={`h-3.5 w-3.5 shrink-0 ${isSelected ? "text-thread" : "text-muted"}`} />
-									<span className="min-w-0 flex-1 truncate">{frame.name}</span>
-								</button>
+								<div key={frame.name}>
+									<div
+										className={`group flex h-8 w-full items-center pr-2 font-mono text-sm leading-sm hover:bg-surface ${
+											isSelected ? "text-text" : "text-muted"
+										}`}
+									>
+										{/* element expansion is design's (#7): live rows carry no chevron */}
+										{mode === "design" ? (
+											<button
+												type="button"
+												aria-label={open ? `Collapse ${frame.name}` : `Expand ${frame.name}`}
+												aria-expanded={open}
+												onClick={() => onToggleFrame(frame.name)}
+												className="flex h-8 w-6 shrink-0 items-center justify-center text-muted hover:text-text"
+											>
+												<ChevronIcon open={open} className="h-2.5 w-2.5" />
+											</button>
+										) : (
+											<span className="w-3 shrink-0" />
+										)}
+										<button
+											type="button"
+											aria-pressed={isSelected}
+											onClick={(event) => onSelectFrame(frame.name, modifiersOf(event))}
+											onDoubleClick={() => onDoubleClickFrame(frame.name)}
+											onKeyDown={(event) => {
+												if (mode !== "design") return;
+												if (event.key === "ArrowRight" && !open) {
+													event.preventDefault();
+													onToggleFrame(frame.name);
+												}
+												if (event.key === "ArrowLeft" && open) {
+													event.preventDefault();
+													onToggleFrame(frame.name);
+												}
+											}}
+											className="flex h-8 min-w-0 flex-1 items-center gap-2 text-left"
+										>
+											<FrameIcon
+												className={`h-3.5 w-3.5 shrink-0 ${isSelected ? "text-thread" : "text-muted"}`}
+											/>
+											<span className="min-w-0 flex-1 truncate">{frame.name}</span>
+											<span className="pr-1 text-2xs text-muted opacity-0 transition-opacity group-hover:opacity-100">
+												frame.tsx
+											</span>
+										</button>
+									</div>
+
+									{open && (
+										<div className="relative pb-1">
+											<span className="absolute top-0 bottom-2 left-[18px] w-px bg-border-raised" />
+											{rows === undefined
+												? pendingWakes.has(frame.name) && (
+														<div className="flex h-7 items-center pl-12 font-mono text-2xs text-muted leading-3">
+															<span className="animate-pulse">waking…</span>
+														</div>
+													)
+												: rows.map((row) => (
+														<TreeRowView
+															key={row.key}
+															depth={0}
+															frame={frame.name}
+															row={row}
+															callSiteLabels={callSiteLabels}
+															expandedRows={expandedRows}
+															pickedKeys={pickedKeys}
+															rowElements={rowElements.current}
+															onSelect={onSelectRow}
+															onDoubleClick={onDoubleClickRow}
+															onToggle={onToggleRow}
+														/>
+													))}
+										</div>
+									)}
+								</div>
 							);
 						})}
+					</div>
+
+					<div className="flex h-9 shrink-0 items-center border-border border-t px-3.5 font-mono text-2xs text-muted leading-3">
+						Shift range · ⌘/Ctrl toggle
 					</div>
 				</div>
 			)}
@@ -168,6 +293,143 @@ export function CanvasSidebar({
 				<span className="absolute top-0 bottom-0 left-[5px] w-px bg-transparent group-hover:bg-thread group-focus-visible:bg-thread" />
 			</button>
 		</aside>
+	);
+}
+
+/** One tree row (#37): slot, label, count — the file-tree design verbatim. */
+function TreeRowView({
+	depth,
+	frame,
+	row,
+	callSiteLabels,
+	expandedRows,
+	pickedKeys,
+	rowElements,
+	onSelect,
+	onDoubleClick,
+	onToggle,
+}: {
+	depth: number;
+	frame: string;
+	row: TreeRow;
+	callSiteLabels: Record<string, string | null>;
+	expandedRows: ReadonlySet<string>;
+	pickedKeys: ReadonlySet<string>;
+	rowElements: Map<string, HTMLElement>;
+	onSelect: (frame: string, row: TreeRow, modifiers: SelectModifiers) => void;
+	onDoubleClick: (frame: string, row: TreeRow) => void;
+	onToggle: (key: string) => void;
+}) {
+	const branch = row.children.length > 0;
+	const open = branch && expandedRows.has(row.key);
+	const selectors = rowSelectors(row);
+	const isSelected = selectors.length > 0 && selectors.every((selector) => pickedKeys.has(pickKey(frame, selector)));
+	const connectorLeft = 18 + depth * ROW_INDENT;
+	const slot = row.kind === "instance" ? `[${row.index}]` : row.kind === "boundary" ? "<…>" : `<${row.tag}>`;
+	const label =
+		row.kind === "element" || row.kind === "instance"
+			? row.label
+			: row.kind === "boundary"
+				? row.basename
+				: (callSiteLabels[row.source] ?? "");
+	const count = row.kind === "callsite" ? row.count : undefined;
+
+	return (
+		<div>
+			<div
+				ref={(el) => {
+					if (el === null) rowElements.delete(row.key);
+					else rowElements.set(row.key, el);
+				}}
+				className={`relative flex h-7 w-full items-center text-xs leading-xs hover:bg-surface ${
+					isSelected ? "bg-surface text-text" : "text-muted"
+				}`}
+			>
+				<span className="absolute top-1/2 h-px w-2.5 bg-border-raised" style={{ left: connectorLeft }} />
+				{branch && (
+					<button
+						type="button"
+						aria-label={open ? `Collapse ${label || slot}` : `Expand ${label || slot}`}
+						aria-expanded={open}
+						onClick={() => onToggle(row.key)}
+						className="absolute z-10 flex h-7 w-5 items-center justify-center text-muted hover:text-text"
+						style={{ left: 24 + depth * ROW_INDENT }}
+					>
+						<ChevronIcon open={open} className="h-2.5 w-2.5" />
+					</button>
+				)}
+				<button
+					type="button"
+					aria-pressed={isSelected}
+					title={count === undefined ? label || slot : `${label || slot} · ${count} rendered`}
+					onClick={(event) => onSelect(frame, row, modifiersOf(event))}
+					onDoubleClick={() => onDoubleClick(frame, row)}
+					onKeyDown={(event) => {
+						if (event.key === "ArrowRight" && branch && !open) {
+							event.preventDefault();
+							onToggle(row.key);
+						}
+						if (event.key === "ArrowLeft" && branch && open) {
+							event.preventDefault();
+							onToggle(row.key);
+						}
+					}}
+					className="flex h-7 w-full min-w-0 items-center gap-2 pr-3 text-left"
+					style={{ paddingLeft: 48 + depth * ROW_INDENT }}
+				>
+					<span className={`w-[54px] shrink-0 font-mono text-2xs ${isSelected ? "text-thread" : "text-muted"}`}>
+						{slot}
+					</span>
+					<span className="min-w-0 flex-1 truncate">{label}</span>
+					{count !== undefined && <span className="shrink-0 font-mono text-2xs text-muted">{count}</span>}
+				</button>
+			</div>
+
+			{open && (
+				<div className="relative">
+					<span
+						className="absolute top-0 bottom-1 w-px bg-border-raised"
+						style={{ left: connectorLeft + ROW_INDENT }}
+					/>
+					{row.children.map((child) => (
+						<TreeRowView
+							key={child.key}
+							depth={depth + 1}
+							frame={frame}
+							row={child}
+							callSiteLabels={callSiteLabels}
+							expandedRows={expandedRows}
+							pickedKeys={pickedKeys}
+							rowElements={rowElements}
+							onSelect={onSelect}
+							onDoubleClick={onDoubleClick}
+							onToggle={onToggle}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function ChevronIcon({ className, open }: { className?: string; open: boolean }) {
+	return (
+		<svg
+			viewBox="0 0 12 12"
+			className={`origin-center transition-transform duration-150 motion-reduce:transition-none ${
+				open ? "rotate-90" : ""
+			} ${className ?? ""}`}
+			fill="none"
+			aria-hidden="true"
+		>
+			<path
+				d="m4 2.5 3.5 3.5L4 9.5"
+				stroke="currentColor"
+				strokeWidth="1.25"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
 	);
 }
 


### PR DESCRIPTION
Closes #37.

Implements the settled spec from the grilling session: multi-element selection spine (elements list on the selection contract, N overlay boxes, shift-toggle, Esc grammar, design-mode hover previews), tree extraction (shim DOM walk grouped by stamps, call-site rows, boundary rows), the sidebar tree UI on the #39 shell, wake-on-expand through a new queue tier, and two-way selection sync with editor jumps. ADR 0006 and the CONTEXT.md glossary amended for the wake-queue change.