### PR TITLE
fix: hold the agent turn past the request that started it

### DIFF
--- a/.changeset/agent-turn-survives-a-refresh.md
+++ b/.changeset/agent-turn-survives-a-refresh.md
@@ -1,0 +1,11 @@
+---
+"spool.page": minor
+---
+
+Refreshing the page no longer kills the agent. A turn belongs to the daemon now, not to the browser tab reading it, so a reload, a closed lid or a few seconds of dropped wifi leaves it working. When the canvas comes back it goes and finds the turn still running in that thread, replays what it missed, and carries on from there. The work in flight is not lost and nothing is drawn twice.
+
+Two things stop a turn, and both are a hand: the stop under the composer, and closing the thread it belongs to.
+
+A turn that finished while you were away is kept readable for five minutes, so you come back to how it actually ended instead of a thread marked stopped.
+
+Messages you queued while the agent was working are kept with the thread, so a refresh no longer drops them. And when a stream really does die, the rail says what happened instead of the same six words for every cause.

--- a/src/daemon/agent-answer.test.ts
+++ b/src/daemon/agent-answer.test.ts
@@ -2,6 +2,7 @@ import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	agentReader,
 	CAPTURES,
 	type FakeAgentProc,
 	fixtureAgentExecutor,
@@ -10,7 +11,6 @@ import {
 	makeTempDir,
 	readCapture,
 	replayAgentExecutor,
-	sseReader,
 	until,
 } from "../test-helpers";
 import { createClaudeAdapter } from "./agent-claude";
@@ -48,7 +48,7 @@ function answer(name: string, app: ReturnType<typeof makeApp>, body: unknown) {
 }
 
 async function drainTurn(res: Response, limit = 4000): Promise<AgentEvent[]> {
-	const events = sseReader(res);
+	const events = agentReader(res);
 	const seen: AgentEvent[] = [];
 	while (seen.length < limit) {
 		try {
@@ -167,7 +167,7 @@ describe("answering", () => {
 		const project = makeProject(spoolDir);
 		const agent = onPrompt((proc) => proc.emit(JSON.stringify(capturedAsk(index))));
 		const app = makeApp(spoolDir, { agentExecutor: agent.executor });
-		const events = sseReader(await startTurn(project.name, app));
+		const events = agentReader(await startTurn(project.name, app));
 		const asking = (await events.next()).data as AgentEvent;
 		if (asking.kind !== "asking") throw new Error(`expected an ask, got ${asking.kind}`);
 		return { ...project, spoolDir, app, agent, events, asking };

--- a/src/daemon/agent-live.test.ts
+++ b/src/daemon/agent-live.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import { until } from "../test-helpers";
+import type { AgentEvent } from "./agent-events";
+import { type AgentHeld, createAgentTurns, holdAgentTurn } from "./agent-live";
+import type { AgentTurn } from "./agent-turn";
+
+/**
+ * A turn nobody is watching, and a turn two people are (#211).
+ *
+ * The turn is stubbed rather than spawned, because what is under test is the holding: the
+ * log accumulating with no reader, a viewer leaving without the turn noticing, and a
+ * second viewer rebuilding what the first one saw.
+ */
+
+function fakeTurn() {
+	const queue: AgentEvent[] = [];
+	let waiting: (() => void) | undefined;
+	let finished = false;
+	let abandoned = false;
+	let interrupts = 0;
+
+	const push = (event: AgentEvent) => {
+		queue.push(event);
+		waiting?.();
+		waiting = undefined;
+	};
+
+	const finish = () => {
+		finished = true;
+		waiting?.();
+		waiting = undefined;
+	};
+
+	async function* events(): AsyncGenerator<AgentEvent> {
+		for (;;) {
+			while (queue.length > 0) yield queue.shift() as AgentEvent;
+			if (finished) return;
+			await new Promise<void>((resolve) => {
+				waiting = resolve;
+			});
+		}
+	}
+
+	const turn: AgentTurn = {
+		events: { [Symbol.asyncIterator]: () => events() },
+		answer: () => true,
+		interrupt: () => {
+			interrupts += 1;
+			return true;
+		},
+		abandon: () => {
+			abandoned = true;
+			finish();
+		},
+	};
+	return {
+		turn,
+		push,
+		finish,
+		says: (text: string): AgentEvent => ({ kind: "say", block: 0, text, parent: null }),
+		get abandoned() {
+			return abandoned;
+		},
+		get interrupts() {
+			return interrupts;
+		},
+	};
+}
+
+/** everything a viewer sees, read to the end of what is there rather than to the end of time */
+async function read(held: AgentHeld, from = 0): Promise<AgentEvent[]> {
+	const seen: AgentEvent[] = [];
+	const view = held.watch(from);
+	const done = (async () => {
+		for await (const one of view) seen.push(one.event);
+	})();
+	await until(() => seen.length >= held.logged - from);
+	view.close();
+	await done;
+	return seen;
+}
+
+describe("holding a turn", () => {
+	it("drains the process with nobody reading, and hands the whole log to whoever arrives", async () => {
+		const fake = fakeTurn();
+		const held = holdAgentTurn({ root: "/p", thread: "t", id: "turn-1", turn: fake.turn });
+
+		// the drain is the turn's own: these land in the log with no viewer in sight, which
+		// is the whole of what #211 changed about who owns a turn
+		fake.push(fake.says("one"));
+		fake.push(fake.says("two"));
+		await until(() => held.logged === 2);
+
+		expect(await read(held)).toEqual([fake.says("one"), fake.says("two")]);
+		expect(fake.abandoned).toBe(false);
+	});
+
+	it("lets a viewer go without the turn going with it", async () => {
+		const fake = fakeTurn();
+		const held = holdAgentTurn({ root: "/p", thread: "t", turn: fake.turn });
+		fake.push(fake.says("one"));
+
+		const view = held.watch(0);
+		const seen: AgentEvent[] = [];
+		const reading = (async () => {
+			for await (const one of view) seen.push(one.event);
+		})();
+		await until(() => seen.length === 1);
+		// the refresh: this reader is gone and the process is not
+		view.close();
+		await reading;
+
+		expect(held.running).toBe(true);
+		expect(fake.abandoned).toBe(false);
+
+		// and the turn goes on writing into a log the next viewer will read
+		fake.push(fake.says("two"));
+		await until(() => held.logged === 2);
+		expect(await read(held)).toEqual([fake.says("one"), fake.says("two")]);
+	});
+
+	it("reads from where a viewer left off, and follows what arrives after", async () => {
+		const fake = fakeTurn();
+		const held = holdAgentTurn({ root: "/p", thread: "t", turn: fake.turn });
+		fake.push(fake.says("one"));
+		fake.push(fake.says("two"));
+		await until(() => held.logged === 2);
+
+		const view = held.watch(2);
+		const seen: AgentEvent[] = [];
+		const reading = (async () => {
+			for await (const one of view) seen.push(one.event);
+		})();
+		// nothing it already had, and everything after it
+		fake.push(fake.says("three"));
+		await until(() => seen.length === 1);
+		expect(seen).toEqual([fake.says("three")]);
+
+		view.close();
+		await reading;
+	});
+
+	it("feeds two viewers of the same turn at once, each from its own place", async () => {
+		const fake = fakeTurn();
+		const held = holdAgentTurn({ root: "/p", thread: "t", turn: fake.turn });
+		fake.push(fake.says("one"));
+		await until(() => held.logged === 1);
+
+		const [whole, tail] = await Promise.all([
+			(async () => {
+				const first = held.watch(0);
+				const seen: AgentEvent[] = [];
+				const reading = (async () => {
+					for await (const one of first) seen.push(one.event);
+				})();
+				await until(() => seen.length === 2);
+				first.close();
+				await reading;
+				return seen;
+			})(),
+			(async () => {
+				const second = held.watch(1);
+				const seen: AgentEvent[] = [];
+				const reading = (async () => {
+					for await (const one of second) seen.push(one.event);
+				})();
+				await until(() => seen.length === 1);
+				second.close();
+				await reading;
+				return seen;
+			})(),
+			(async () => {
+				await until(() => held.logged === 1);
+				fake.push(fake.says("two"));
+			})(),
+		]);
+
+		expect(whole).toEqual([fake.says("one"), fake.says("two")]);
+		expect(tail).toEqual([fake.says("two")]);
+	});
+
+	it("ends the read when the turn is over rather than parking it forever", async () => {
+		const fake = fakeTurn();
+		const held = holdAgentTurn({ root: "/p", thread: "t", turn: fake.turn });
+		fake.push(fake.says("one"));
+
+		const seen: AgentEvent[] = [];
+		const reading = (async () => {
+			for await (const one of held.watch(0)) seen.push(one.event);
+		})();
+		await until(() => seen.length === 1);
+		fake.finish();
+
+		// the read returns on its own: a viewer parked on the tail of a turn that is over is
+		// a browser tab waiting on a process that has exited
+		await reading;
+		expect(held.running).toBe(false);
+	});
+});
+
+describe("the turns this daemon is holding", () => {
+	it("keeps an ended turn readable for its grace window, then lets it go", async () => {
+		const turns = createAgentTurns(40);
+		const fake = fakeTurn();
+		const held = turns.hold({ root: "/p", thread: "t", turn: fake.turn });
+		fake.push(fake.says("done"));
+		await until(() => held.logged === 1);
+		fake.finish();
+		await until(() => !held.running);
+
+		// still there the instant it ends, which is what lets a client that was away read the
+		// ending rather than the rail inventing a `stopped` for it
+		expect(turns.get("/p", "t")).toBe(held);
+		expect(await read(turns.get("/p", "t") as AgentHeld)).toEqual([fake.says("done")]);
+
+		await until(() => turns.get("/p", "t") === undefined);
+		expect(turns.threads("/p").size).toBe(0);
+	});
+
+	it("holds one turn per conversation and keeps two projects apart", () => {
+		const turns = createAgentTurns();
+		const one = turns.hold({ root: "/one", thread: "t", turn: fakeTurn().turn });
+		const two = turns.hold({ root: "/two", thread: "t", turn: fakeTurn().turn });
+
+		// the same thread id in two projects is two turns, because the key is both
+		expect(turns.get("/one", "t")).toBe(one);
+		expect(turns.get("/two", "t")).toBe(two);
+		expect([...turns.of("/one")]).toEqual([one]);
+		expect(turns.threads("/two")).toEqual(new Set(["t"]));
+		turns.close();
+	});
+
+	it("takes the process with it when the daemon closes, which is the one blunt exit", async () => {
+		const turns = createAgentTurns();
+		const fake = fakeTurn();
+		turns.hold({ root: "/p", thread: "t", turn: fake.turn });
+
+		turns.close();
+
+		expect(fake.abandoned).toBe(true);
+		expect(turns.get("/p", "t")).toBeUndefined();
+		// and the entry does not come back on the ending its own abandon reported
+		await until(() => turns.get("/p", "t") === undefined);
+	});
+
+	it("passes a stop through to the turn it names", () => {
+		const turns = createAgentTurns();
+		const fake = fakeTurn();
+		const held = turns.hold({ root: "/p", thread: "t", id: "turn-1", turn: fake.turn });
+
+		expect(held.id).toBe("turn-1");
+		expect(held.interrupt()).toBe(true);
+		expect(fake.interrupts).toBe(1);
+		// a stop is not a kill: the process survives it and ends the turn itself
+		expect(fake.abandoned).toBe(false);
+		turns.close();
+	});
+});

--- a/src/daemon/agent-live.ts
+++ b/src/daemon/agent-live.ts
@@ -1,0 +1,238 @@
+import type { AgentReply } from "./agent-control";
+import type { AgentEvent } from "./agent-events";
+import type { AgentTurn } from "./agent-turn";
+
+/**
+ * A turn that outlives the request that started it (#211).
+ *
+ * #191 gave the turn one owner and it was the wrong one: the process lived for exactly
+ * as long as the POST whose response streamed it, so a refresh, a closed lid or two
+ * seconds of dropped wifi killed the binary mid-edit. The conversation survived — the
+ * thread id is the binary's own session id and the next message resumes it — but the
+ * work in flight did not, and neither did the queue that was waiting on it.
+ *
+ * So the turn is held here and the stream is only a view of it. A viewer arrives, reads
+ * the log from wherever it left off, follows what comes next, and leaves without the
+ * process noticing. What kills a turn is a hand on the stop or the daemon closing, and
+ * nothing else.
+ *
+ * **The log is kept whole and replayed from the top by default.** It is the same
+ * decision #120 made about the picture, one layer down: the rail folds the event union
+ * into a transcript and that fold is pure, so handing back every event a turn has
+ * produced rebuilds exactly what was on screen — no second fold down here, and no
+ * vocabulary to keep in step. What it costs is one turn's events in memory, which is
+ * the same bytes the client was already holding.
+ *
+ * **An ended turn is kept for a while.** A turn that finished while nobody was watching
+ * has an ending nobody has read, and the alternative is the rail inventing one: a stored
+ * picture that says `running` with no live turn under it reads as cut, which is a lie
+ * about a turn that finished cleanly. So the log stays reachable for a grace window
+ * after the process is gone.
+ */
+
+/** one event and the id a viewer resumes after, which is its index in the log */
+export interface AgentLogged {
+	readonly id: number;
+	readonly event: AgentEvent;
+}
+
+/** a viewer's own read of the log, which it can give up without the turn ending */
+export interface AgentView extends AsyncIterable<AgentLogged> {
+	/** stop this read where it stands — the client went away, and the turn has not */
+	close(): void;
+}
+
+export interface AgentHeld {
+	readonly root: string;
+	readonly thread: string;
+	/** what the rail calls this turn, which is the address its stop names (#165) */
+	readonly id: string | undefined;
+	/** the process is still up: a held turn outlives it by the grace window */
+	readonly running: boolean;
+	/** how much has arrived, which is what a fresh viewer is told it is replaying */
+	readonly logged: number;
+	answer(request: string, reply: AgentReply): boolean;
+	interrupt(): boolean;
+	/** the blunt one: the daemon is closing, or this thread is being talked to again */
+	abandon(): void;
+	/** read from `from` onward — what is already logged, and then what arrives */
+	watch(from: number): AgentView;
+}
+
+export interface AgentHoldOptions {
+	readonly root: string;
+	readonly thread: string;
+	readonly id?: string | undefined;
+	readonly turn: AgentTurn;
+	/** the process is gone: the caller starts its own grace window from here */
+	readonly onEnded?: (() => void) | undefined;
+}
+
+/**
+ * Hold one turn, and drain it whether or not anybody is reading.
+ *
+ * The drain is the whole point. #191 pulled events out of the turn inside the SSE
+ * handler, so a turn with no viewer was a turn nobody was pulling — which is why the
+ * process had to die with the request. Here the drain is the turn's own, started the
+ * moment it is held, and a viewer is a second reader of what it wrote down.
+ */
+export function holdAgentTurn({ root, thread, id, turn, onEnded }: AgentHoldOptions): AgentHeld {
+	const log: AgentEvent[] = [];
+	let running = true;
+	/** every viewer parked on the tail, woken together whenever the tail moves */
+	const waiting = new Set<() => void>();
+
+	function wake(): void {
+		for (const resolve of waiting) resolve();
+		waiting.clear();
+	}
+
+	function stop(): void {
+		if (!running) return;
+		running = false;
+		wake();
+		onEnded?.();
+	}
+
+	void (async () => {
+		for await (const event of turn.events) {
+			log.push(event);
+			wake();
+		}
+		stop();
+	})();
+
+	function watch(from: number): AgentView {
+		let closed = false;
+		let next = Math.max(0, Math.min(from, log.length));
+		const view: AgentView = {
+			close: () => {
+				closed = true;
+				wake();
+			},
+			async *[Symbol.asyncIterator]() {
+				for (;;) {
+					while (next < log.length) {
+						if (closed) return;
+						const event = log[next];
+						// the log only ever grows, so an index inside its length is always there —
+						// the guard is for the type rather than for a case
+						if (event === undefined) return;
+						yield { id: next, event };
+						next += 1;
+					}
+					// the tail is caught up: a turn that is over has nothing more to say, and one
+					// that is not parks this viewer until it does
+					if (closed || !running) return;
+					await new Promise<void>((resolve) => waiting.add(resolve));
+				}
+			},
+		};
+		return view;
+	}
+
+	return {
+		root,
+		thread,
+		id,
+		get running() {
+			return running;
+		},
+		get logged() {
+			return log.length;
+		},
+		answer: (request, reply) => turn.answer(request, reply),
+		interrupt: () => turn.interrupt(),
+		abandon: () => {
+			turn.abandon();
+			stop();
+		},
+		watch,
+	};
+}
+
+/** how long an ended turn stays readable, so a client that was away reads its ending */
+const KEPT_MS = 5 * 60_000;
+
+export interface AgentTurns {
+	get(root: string, thread: string): AgentHeld | undefined;
+	hold(options: Omit<AgentHoldOptions, "onEnded">): AgentHeld;
+	/** the turns of one project, for the doors addressed by something other than a thread */
+	of(root: string): Iterable<AgentHeld>;
+	/** every thread this daemon can still show a turn for, live or lately ended */
+	threads(root: string): Set<string>;
+	close(): void;
+}
+
+/**
+ * Every turn this daemon is holding, by the conversation it belongs to (#211).
+ *
+ * Keyed by thread rather than by turn, because a thread is a conversation and a
+ * conversation has one turn running in it: that is what lets a reconnecting rail ask for
+ * *the turn in this thread* without having to remember what the turn it lost was called.
+ *
+ * A held turn is dropped when its grace window closes, when the thread is talked to
+ * again, or when the daemon shuts down.
+ */
+export function createAgentTurns(keptMs = KEPT_MS): AgentTurns {
+	const held = new Map<string, AgentHeld>();
+	const timers = new Map<string, ReturnType<typeof setTimeout>>();
+	const keyOf = (root: string, thread: string) => `${root} ${thread}`;
+
+	function drop(key: string): void {
+		const timer = timers.get(key);
+		if (timer !== undefined) clearTimeout(timer);
+		timers.delete(key);
+		// out of the map before it is abandoned, so the ending its own abandon reports finds
+		// nothing to start a grace window for: a timer set from here would outlive the entry
+		// and come due against whatever the thread was holding by then
+		const going = held.get(key);
+		held.delete(key);
+		going?.abandon();
+	}
+
+	function keep(key: string): void {
+		const timer = setTimeout(() => drop(key), keptMs);
+		// a grace window is not a reason to keep the process alive: a daemon with nothing
+		// left to do exits, and the log goes with it
+		timer.unref();
+		timers.set(key, timer);
+	}
+
+	function* of(root: string): Iterable<AgentHeld> {
+		for (const one of held.values()) if (one.root === root) yield one;
+	}
+
+	return {
+		get: (root, thread) => held.get(keyOf(root, thread)),
+		/*
+		 * Take a turn, replacing whatever this thread was holding.
+		 *
+		 * A running one is never replaced silently — the door refuses a second turn in a
+		 * thread that already has one — so what this drops is only ever an ended turn still
+		 * inside its grace window, and a thread being talked to again is the end of anybody's
+		 * interest in the turn before it.
+		 */
+		hold: (options) => {
+			const key = keyOf(options.root, options.thread);
+			drop(key);
+			const taken: AgentHeld = holdAgentTurn({
+				...options,
+				onEnded: () => {
+					if (held.get(key) === taken) keep(key);
+				},
+			});
+			held.set(key, taken);
+			return taken;
+		},
+		of,
+		threads: (root) => {
+			const live = new Set<string>();
+			for (const one of of(root)) live.add(one.thread);
+			return live;
+		},
+		close: () => {
+			for (const key of [...held.keys()]) drop(key);
+		},
+	};
+}

--- a/src/daemon/agent-threads.test.ts
+++ b/src/daemon/agent-threads.test.ts
@@ -36,7 +36,9 @@ const picture: ThreadPut = {
 		{ key: "u0", kind: "user", text: "shoot home and fix whatever reads wrong", context: null, attached: null },
 		{ key: "row:t1", kind: "row", state: "done", verb: "shot", subject: "home" },
 	],
+	kept: 2,
 	plan: null,
+	queued: [],
 };
 
 const noSessions = { HOME: "/nowhere" };

--- a/src/daemon/agent-threads.ts
+++ b/src/daemon/agent-threads.ts
@@ -53,8 +53,33 @@ export interface StoredThread {
 	readonly at: number;
 	/** the drawn transcript, exactly as the rail drew it */
 	readonly entries: ThreadPicture;
+	/**
+	 * How many of those entries are not drawn from the turn in flight (#211).
+	 *
+	 * The boundary between the conversation and the turn on top of it, which only the rail
+	 * knows: it holds the earlier turns as drawn entries and folds the live one out of its
+	 * events every tick. A client coming back to a turn this daemon is still holding keeps
+	 * this much of the picture and refolds the rest off the replayed log — where taking the
+	 * whole picture would draw the live turn twice, once off disk and once off the wire.
+	 *
+	 * Everything, for a thread with nothing running: a stored picture with no turn under it
+	 * is all conversation, which is also what a file written before #211 reads as.
+	 */
+	readonly kept: number;
 	/** the plan the turn wrote, which is drawn state and so is stored state */
 	readonly plan: unknown;
+	/**
+	 * What spool is holding until this turn ends, in the order it will fire (#170, #211).
+	 *
+	 * Stored for the reason the picture is: it lives in a browser, and a browser is the one
+	 * place a thing can be lost by a keystroke. A refresh used to drop every queued message
+	 * silently — the words were spool's to hold and spool held them in memory only.
+	 *
+	 * Opaque here, like the entries and for the same reason: what a queued message *is* is
+	 * the rail's vocabulary, and a second opinion about its shape down here would be a
+	 * second copy to keep in step.
+	 */
+	readonly queued: ThreadPicture;
 	/** a restart caught this thread mid-turn: it stopped, and it is never resumed */
 	readonly stopped: boolean;
 	/** closing a tab tidies it out of the strip and deletes nothing */
@@ -85,6 +110,16 @@ const WORKING: ReadonlySet<StoredLife> = new Set<StoredLife>(["running", "waitin
  */
 export interface ServedThread extends StoredThread {
 	readonly continuable: boolean;
+	/**
+	 * This daemon is still holding a turn for it, so there is a stream to pick up (#211).
+	 *
+	 * Not the same fact as `stopped`, and the two are opposites on purpose: a thread whose
+	 * picture says a process was up is either one this daemon can still show you — attach,
+	 * replay, carry on — or one whose process went with something that was not a hand. Which
+	 * of the two it is is the only thing the rail needs to decide between reconnecting and
+	 * drawing a cut.
+	 */
+	readonly live: boolean;
 }
 
 /**
@@ -123,12 +158,20 @@ function parseEnvelope(value: unknown): ThreadPut | undefined {
 	if (!STORED.includes(record.life as StoredLife)) return undefined;
 	if (!Array.isArray(record.entries)) return undefined;
 	if (record.at !== undefined && (typeof record.at !== "number" || !Number.isFinite(record.at))) return undefined;
+	// a picture with no boundary in it is a picture with nothing running under it, which is
+	// what every file written before #211 is and what a finished thread means either way
+	const kept =
+		typeof record.kept === "number" && Number.isInteger(record.kept) && record.kept >= 0
+			? Math.min(record.kept, record.entries.length)
+			: record.entries.length;
 	return {
 		ask: record.ask,
 		life: record.life as StoredLife,
 		at: typeof record.at === "number" ? record.at : Date.now(),
 		entries: record.entries,
+		kept,
 		plan: record.plan ?? null,
+		queued: Array.isArray(record.queued) ? record.queued : [],
 	};
 }
 
@@ -235,12 +278,17 @@ export function serveThreads(
 		 * because a background process came back up is spool taking an action nobody asked
 		 * for at that moment.
 		 *
-		 * What identifies one is the store against this daemon's own live turns: a thread
-		 * whose picture says a process was up, with nothing running under that id here,
-		 * lost its process to something that was not a hand. It costs nearly nothing to
-		 * pick up — the agent's memory is intact and one word resumes it.
+		 * What identifies one is the store against this daemon's own held turns: a thread
+		 * whose picture says a process was up, with nothing held under that id here, lost its
+		 * process to something that was not a hand. It costs nearly nothing to pick up — the
+		 * agent's memory is intact and one word resumes it.
+		 *
+		 * It says far less than it used to, and that is #211 landing rather than a change of
+		 * rule: a turn now outlives the request that streamed it, so a refresh no longer cuts
+		 * one, and what is left here means what it always claimed to — the daemon went away.
 		 */
-		const cut = WORKING.has(thread.life) && !live.has(thread.id);
+		const held = live.has(thread.id);
+		const cut = WORKING.has(thread.life) && !held;
 		const stopped = thread.stopped || cut;
 		return {
 			...thread,
@@ -248,6 +296,7 @@ export function serveThreads(
 			// a thread that was working when the lights went out has changed since anybody
 			// looked at it, and the change is that it stopped
 			life: cut ? "unread" : thread.life,
+			live: held,
 			continuable: sessionExists(root, thread.id, env),
 		};
 	});

--- a/src/daemon/agent-turn.test.ts
+++ b/src/daemon/agent-turn.test.ts
@@ -3,13 +3,13 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { MAX_ATTACHMENT_BYTES } from "../attachment";
 import {
+	agentReader,
 	fixtureAgentExecutor,
 	makeApp,
 	makeProject,
 	makeTempDir,
 	readCapture,
 	replayAgentExecutor,
-	sseReader,
 	until,
 	writeFrame,
 } from "../test-helpers";
@@ -21,7 +21,7 @@ import { startAgentTurn } from "./agent-turn";
 
 /** Every event of one turn, read off the stream the way a client would. */
 async function drainTurn(res: Response, limit = 4000): Promise<AgentEvent[]> {
-	const events = sseReader(res);
+	const events = agentReader(res);
 	const seen: AgentEvent[] = [];
 	while (seen.length < limit) {
 		let next: Awaited<ReturnType<typeof events.next>>;
@@ -99,6 +99,122 @@ describe("one turn over the wire", () => {
 		expect(kinds.slice(0, 6)).toEqual(["ready", "limit", "call-input", "call-input", "called", "call"]);
 		expect(kinds.filter((kind) => kind === "ended")).toHaveLength(1);
 		expect(kinds.indexOf("ended")).toBe(kinds.length - 2);
+	});
+
+	/*
+	 * A turn is not the request's to end (#211).
+	 *
+	 * The whole of what the ticket is about, at the door: the reader goes away, the process
+	 * stays up, and whoever comes back reads what happened while nobody was looking.
+	 */
+	it("outlives the reader that started it, and hands the whole turn to the next one", async () => {
+		const spoolDir = join(makeTempDir(), ".spool");
+		const { name } = makeProject(spoolDir);
+		const agent = fixtureAgentExecutor();
+		const app = makeApp(spoolDir, { agentExecutor: agent.executor });
+
+		const res = await startTurn(name, app);
+		await until(() => agent.spawned.length === 1);
+		const proc = agent.spawned[0] as (typeof agent.spawned)[number];
+		proc.emit(
+			JSON.stringify({
+				type: "stream_event",
+				event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "before" } },
+			}),
+		);
+
+		// the refresh: this reader is gone, and it takes nothing with it
+		const events = agentReader(res);
+		expect((await events.next()).data).toMatchObject({ kind: "say", text: "before" });
+		await events.cancel();
+		proc.emit(
+			JSON.stringify({
+				type: "stream_event",
+				event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "after" } },
+			}),
+		);
+
+		expect(proc.killed).toBe(false);
+
+		// and the page that comes back gets the turn from the top: what it missed and what it
+		// was never there for, in one read
+		const again = await app.request(`/api/p/${name}/agent/turn/${THREAD}`);
+		expect(again.status).toBe(200);
+		const back = agentReader(again);
+		// the turn introduces itself first: what it is called, whether it is up, and how much
+		// of what follows already happened
+		const opening = await back.opening();
+		expect(opening.event).toBe("attached");
+		expect(opening.data).toMatchObject({ running: true, from: 0 });
+		expect((await back.next()).data).toMatchObject({ kind: "say", text: "before" });
+		expect((await back.next()).data).toMatchObject({ kind: "say", text: "after" });
+		await back.cancel();
+	});
+
+	it("refuses a second turn in a conversation that already has one running", async () => {
+		const spoolDir = join(makeTempDir(), ".spool");
+		const { name } = makeProject(spoolDir);
+		const agent = fixtureAgentExecutor();
+		const app = makeApp(spoolDir, { agentExecutor: agent.executor });
+
+		const first = await startTurn(name, app);
+		await until(() => agent.spawned.length === 1);
+
+		const second = await startTurn(name, app, "and this too");
+		expect(second.status).toBe(409);
+		expect(await second.text()).toContain("already running");
+		// one process, because two agents writing the same files is the thing being refused
+		expect(agent.spawned).toHaveLength(1);
+		await agentReader(first).cancel();
+	});
+
+	it("says there is nothing to read where no turn is being held", async () => {
+		const spoolDir = join(makeTempDir(), ".spool");
+		const { name } = makeProject(spoolDir);
+		const app = makeApp(spoolDir, { agentExecutor: fixtureAgentExecutor().executor });
+
+		const res = await app.request(`/api/p/${name}/agent/turn/${THREAD}`);
+		expect(res.status).toBe(404);
+		// the ordinary answer for every thread that is not mid-turn, and not a failure: the
+		// picture on disk is the whole of what the rail draws for one of those
+		expect(await res.text()).toContain("no turn to read");
+
+		const bad = await app.request(`/api/p/${name}/agent/turn/not-a-uuid`);
+		expect(bad.status).toBe(400);
+	});
+
+	it("tells the rail which threads have a turn to pick up", async () => {
+		const spoolDir = join(makeTempDir(), ".spool");
+		const { name } = makeProject(spoolDir);
+		const agent = fixtureAgentExecutor();
+		const app = makeApp(spoolDir, { agentExecutor: agent.executor });
+
+		const res = await startTurn(name, app);
+		await until(() => agent.spawned.length === 1);
+		await app.request(`/api/p/${name}/agent/threads/${THREAD}`, {
+			method: "PUT",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				ask: "make these consistent",
+				life: "running",
+				at: 1_700_000_000_000,
+				entries: [{ key: "u0", kind: "user", text: "make these consistent" }],
+				kept: 1,
+				plan: null,
+				queued: [],
+			}),
+		});
+
+		const listed = (await (await app.request(`/api/p/${name}/agent/threads`)).json()) as {
+			threads: { id: string; live: boolean; stopped: boolean }[];
+		};
+		const thread = listed.threads.find((one) => one.id === THREAD);
+		// live and not cut, which are the two halves of the same question: a picture that says
+		// a process was up either has one here to attach to or lost it to something that was
+		// not a hand
+		expect(thread?.live).toBe(true);
+		expect(thread?.stopped).toBe(false);
+		await agentReader(res).cancel();
 	});
 
 	it("sends the prompt as one line of structured input", async () => {
@@ -427,7 +543,7 @@ describe("the thread a turn runs under", () => {
 		const args: readonly string[] = agent.spawned[0]?.spawn.args ?? [];
 		expect(args[args.indexOf("--session-id") + 1]).toBe(THREAD);
 		expect(args).not.toContain("--resume");
-		await res.body?.cancel();
+		await agentReader(res).cancel();
 	});
 
 	it("resumes it once the binary has a session file under that id", async () => {
@@ -448,7 +564,7 @@ describe("the thread a turn runs under", () => {
 		const args: readonly string[] = agent.spawned[0]?.spawn.args ?? [];
 		expect(args[args.indexOf("--resume") + 1]).toBe(THREAD);
 		expect(args).not.toContain("--session-id");
-		await res.body?.cancel();
+		await agentReader(res).cancel();
 		vi.unstubAllEnvs();
 	});
 });

--- a/src/daemon/app.ts
+++ b/src/daemon/app.ts
@@ -22,11 +22,12 @@ import { gridToSvg } from "../term/still";
 import { requestUpgrade } from "../upgrade";
 import { parseAgentReply } from "./agent-control";
 import { type AgentExecutor, claudeExecutor } from "./agent-exec";
+import { type AgentHeld, createAgentTurns } from "./agent-live";
 import { type AgentAsk, askAgentOffer, askFrom, isEffortShaped, isModelShaped } from "./agent-offer";
 import { agentInstalled, askAgentLogin } from "./agent-preflight";
 import { agentPromptContent } from "./agent-spawn";
 import { closeThread, isThreadId, parseThreadPut, putThread, serveThreads, sessionExists } from "./agent-threads";
-import { type AgentTurn, startAgentTurn } from "./agent-turn";
+import { startAgentTurn } from "./agent-turn";
 import { createFrameCompiler } from "./compile";
 import { DesignBoundaryError, realDesignDir, resolveDesignPath } from "./design-path";
 import {
@@ -140,6 +141,46 @@ type LaunchEditor = (file: string, onError?: (fileName: string, message: string 
 
 /** launch-editor is CJS `export =` — createRequire keeps the types honest. */
 const launchEditorDefault = createRequire(import.meta.url)("launch-editor") as LaunchEditor;
+
+/**
+ * One view of a held turn, which is what both doors return (#211).
+ *
+ * The turn is not this response's to end. A client that goes away closes its own read and
+ * leaves the process where it was — which is the whole of what #211 changed, and it is one
+ * line: `onAbort` closes the view rather than abandoning the turn.
+ *
+ * It opens by saying what is being read: the name the rail's stop has to quote, whether
+ * the process is still up, and how many events are already in the log. That last one is
+ * what lets the rail draw the replay whole and pace only what arrives after it — the same
+ * rule a picture off disk is under, since neither of them is happening now.
+ */
+function attachTurn(c: Context, held: AgentHeld, from: number) {
+	return streamSSE(c, async (stream) => {
+		const view = held.watch(from);
+		stream.onAbort(() => view.close());
+		try {
+			await stream.writeSSE({
+				event: "attached",
+				data: JSON.stringify({
+					...(held.id === undefined ? {} : { turn: held.id }),
+					running: held.running,
+					from,
+					logged: held.logged,
+				}),
+			});
+			for await (const { id, event } of view) {
+				try {
+					await stream.writeSSE({ event: "agent", data: JSON.stringify(event), id: String(id) });
+				} catch {
+					// the client hung up mid-write — stop reading, and leave the turn running
+					break;
+				}
+			}
+		} finally {
+			view.close();
+		}
+	});
+}
 
 const disabledTermExecutor: TermExecutor = async () => {
 	throw new SpoolError("terminal execution is disabled until it can run in an OS sandbox");
@@ -296,19 +337,16 @@ export function createDaemonApp({
 	// behind the control token, the same boundary #41 drew.
 	const spawnAgent = agentExecutor ?? claudeExecutor();
 	/**
-	 * Every turn in flight, the project it is running in, and what the rail calls it.
+	 * Every turn this daemon is holding, by the conversation it belongs to (#211).
 	 *
-	 * The project is carried because an answer arrives on its own request rather than
-	 * on the stream that asked for it (#197): a waiting request is addressed by the id
-	 * the binary gave it, and this is what keeps one project's answer from reaching
-	 * another project's turn.
-	 *
-	 * The name is carried for the same reason and a different id (#165). A stop has no
-	 * request to quote — it is the one thing spool asks the binary for rather than
-	 * answers — so the rail names its own turn when it starts one, and the stop names
-	 * it back. Absent for a client that never intends to stop anything.
+	 * It used to be every turn *in flight*, keyed by the turn and cleared by the request
+	 * that streamed it — which is what made a refresh kill the binary. A turn is held here
+	 * now and the stream is only a view of it: the project is carried because an answer
+	 * arrives on its own request rather than on the stream that asked for it (#197), and
+	 * the rail's own name for the turn is carried because a stop has no request to quote
+	 * and names the turn instead (#165).
 	 */
-	const liveTurns = new Map<AgentTurn, { root: string; id?: string; thread: string }>();
+	const liveTurns = createAgentTurns();
 	/**
 	 * Which machine each thread chose, and how hard it should think (#199).
 	 *
@@ -933,6 +971,21 @@ export function createDaemonApp({
 				const project = resolveProject(c, c.req.param("project"));
 				if ("response" in project) return project.response;
 				const { said, thread, turn: named } = c.req.valid("json");
+				/*
+				 * One turn per conversation, refused rather than replaced (#211).
+				 *
+				 * A thread holding a running turn is a thread with a process standing in the repo,
+				 * and a second one would be two agents writing the same files against a prompt
+				 * neither of them can see. The rail queues into a running turn rather than sending,
+				 * so this only ever catches a client that lost its stream and came back without
+				 * attaching — and saying so is what sends it to the door below.
+				 */
+				if (liveTurns.get(project.root, thread)?.running === true) {
+					return c.text(
+						`a turn is already running in thread "${thread}" — attach to it rather than starting a second`,
+						409,
+					);
+				}
 				const turn = startAgentTurn({
 					executor: spawnAgent,
 					root: project.root,
@@ -962,25 +1015,52 @@ export function createDaemonApp({
 					// property of the thread rather than of whichever turn last said so
 					ask: agentAsks.get(askKey(project.root, thread)) ?? {},
 				});
-				liveTurns.set(turn, { root: project.root, thread, ...(named === undefined ? {} : { id: named }) });
-				return streamSSE(c, async (stream) => {
-					let id = 0;
-					stream.onAbort(() => turn.abandon());
-					try {
-						for await (const event of turn.events) {
-							try {
-								await stream.writeSSE({ event: "agent", data: JSON.stringify(event), id: String(id++) });
-							} catch {
-								// the client hung up mid-write — stop reading, but never
-								// swallow a failure from the turn itself
-								break;
-							}
-						}
-					} finally {
-						turn.abandon();
-						liveTurns.delete(turn);
-					}
+				const held = liveTurns.hold({
+					root: project.root,
+					thread,
+					turn,
+					...(named === undefined ? {} : { id: named }),
 				});
+				return attachTurn(c, held, 0);
+			},
+		)
+		/*
+		 * The same turn, read again from wherever a client left off (#211).
+		 *
+		 * A refresh, a lid, a dropped socket: the browser loses the response and the turn goes
+		 * on, so what a returning rail needs is not a new turn but the one it was reading. It
+		 * asks for the turn in this thread, says how much of it it has, and gets the rest —
+		 * the log from that point, and then everything that arrives after.
+		 *
+		 * From zero by default, which is what a fresh page asks for: the fold from the event
+		 * union to the drawing is the rail's and it is pure, so handing back every event the
+		 * turn has produced rebuilds exactly what was on screen. Nothing down here folds
+		 * anything, which is #120's seam kept where it was.
+		 */
+		.get(
+			"/api/p/:project/agent/turn/:thread",
+			validator("query", (value) => {
+				// how much of the turn the client already has, which is the id it wants first.
+				// Anything that is not a whole number is a client that has nothing, and that is a
+				// replay rather than a refusal: a bad query must cost the read no events, never
+				// the turn
+				const said = (value as { from?: unknown }).from;
+				const from = Number.parseInt(typeof said === "string" ? said : "", 10);
+				return { from: Number.isInteger(from) && from > 0 ? from : 0 };
+			}),
+			(c) => {
+				const project = resolveProject(c, c.req.param("project"));
+				if ("response" in project) return project.response;
+				const thread = c.req.param("thread");
+				if (!isThreadId(thread)) {
+					return c.text("a thread is named by the uuid its session runs under", 400);
+				}
+				const held = liveTurns.get(project.root, thread);
+				// nothing is being held for this conversation: it ended long enough ago to have
+				// been let go of, or it never ran here. Both are the same fact from here, and the
+				// picture on disk is the whole of what the rail can draw for one of them
+				if (held === undefined) return c.text(`no turn to read in thread "${thread}"`, 404);
+				return attachTurn(c, held, c.req.valid("query").from);
 			},
 		)
 		.post(
@@ -1008,8 +1088,8 @@ export function createDaemonApp({
 				const project = resolveProject(c, c.req.param("project"));
 				if ("response" in project) return project.response;
 				const { turn: named } = c.req.valid("json");
-				for (const [turn, live] of liveTurns) {
-					if (live.root === project.root && live.id === named && turn.interrupt()) return c.body(null, 204);
+				for (const held of liveTurns.of(project.root)) {
+					if (held.id === named && held.interrupt()) return c.body(null, 204);
 				}
 				// nothing is running under that name: it ended on its own, or it was never
 				// this project's. Both are the same fact from here, and both mean stopped
@@ -1044,8 +1124,8 @@ export function createDaemonApp({
 				const project = resolveProject(c, c.req.param("project"));
 				if ("response" in project) return project.response;
 				const { request, reply } = c.req.valid("json");
-				for (const [turn, live] of liveTurns) {
-					if (live.root === project.root && turn.answer(request, reply)) return c.body(null, 204);
+				for (const held of liveTurns.of(project.root)) {
+					if (held.answer(request, reply)) return c.body(null, 204);
 				}
 				// nobody is waiting on it: the turn ended, it was answered already, or it
 				// belongs to another project. All three are the same fact from here
@@ -1065,9 +1145,7 @@ export function createDaemonApp({
 		.get("/api/p/:project/agent/threads", (c) => {
 			const project = resolveProject(c, c.req.param("project"));
 			if ("response" in project) return project.response;
-			const live = new Set<string>();
-			for (const one of liveTurns.values()) if (one.root === project.root) live.add(one.thread);
-			return c.json({ threads: serveThreads(spoolDir, project.root, { live }) });
+			return c.json({ threads: serveThreads(spoolDir, project.root, { live: liveTurns.threads(project.root) }) });
 		})
 		.put(
 			"/api/p/:project/agent/threads/:thread",
@@ -1827,8 +1905,7 @@ export function createDaemonApp({
 		terms,
 		close: () => {
 			machineStateWatch.stop();
-			for (const turn of liveTurns.keys()) turn.abandon();
-			liveTurns.clear();
+			liveTurns.close();
 			void terms.close();
 			hub.close();
 			updateChecker.stop();

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -181,7 +181,56 @@ export function sseReader(res: Response) {
 		throw new Error(`expected quiet, got ${JSON.stringify(seen)}`);
 	}
 
-	return { next, drain, expectQuiet };
+	/** let the response go, which is a client hanging up rather than a stream ending */
+	async function cancel(): Promise<void> {
+		await reader.cancel();
+	}
+
+	return { next, drain, expectQuiet, cancel };
+}
+
+/**
+ * The agent events off a turn's stream, and only those (#211).
+ *
+ * A turn's stream opens by saying what is being read — the name a stop quotes, whether the
+ * process is up, how much of what follows is replay — and that line is the daemon talking
+ * about the turn rather than the agent talking. Every assertion here is about the second
+ * kind, so this is the reader that skips the first. `sseReader` is still what a test about
+ * the opening line itself uses.
+ */
+export function agentReader(res: Response) {
+	const sse = sseReader(res);
+
+	async function next(timeoutMs = 5000): Promise<SseEvent> {
+		const deadline = Date.now() + timeoutMs;
+		for (;;) {
+			const left = deadline - Date.now();
+			if (left <= 0) throw new SseTimeout("timed out waiting for an agent event");
+			const seen = await sse.next(left);
+			if (seen.event === "agent") return seen;
+		}
+	}
+
+	async function drain(quietMs: number): Promise<void> {
+		try {
+			for (;;) await next(quietMs);
+		} catch (error) {
+			if (!(error instanceof SseTimeout)) throw error;
+		}
+	}
+
+	async function expectQuiet(ms: number): Promise<void> {
+		let seen: SseEvent;
+		try {
+			seen = await next(ms);
+		} catch (error) {
+			if (error instanceof SseTimeout) return;
+			throw error;
+		}
+		throw new Error(`expected quiet, got ${JSON.stringify(seen)}`);
+	}
+
+	return { next, drain, expectQuiet, cancel: sse.cancel, opening: sse.next };
 }
 
 /** The terminal fixture executor (#42): the injected stand-in for the bun

--- a/src/ui/api.ts
+++ b/src/ui/api.ts
@@ -348,13 +348,14 @@ export function subscribeSse(url: string, handlers: Record<string, (data: unknow
 }
 
 /**
- * One turn against the developer's own agent (#191, #192).
+ * One turn against the developer's own agent (#191, #192, #211).
  *
- * A POST whose response is the stream, and the one SSE surface here that must
- * never reconnect: a turn is a process the daemon holds open for exactly as long
- * as this request lives, so reopening it would spawn a second agent against a
- * prompt that has already been answered. It ends when the daemon closes it, and
- * abandoning the returned handle takes the process with it.
+ * A POST whose response is the stream, and the one SSE surface here that must never
+ * reconnect *by itself*: reopening the POST would spawn a second agent against a prompt
+ * that has already been answered. What it may do — and what `attachAgentTurn` below is —
+ * is go and read the same turn again through its own door, because the turn no longer
+ * belongs to this request. Letting go of the handle lets go of the read, and the daemon
+ * carries on.
  */
 export interface AgentSaying {
 	readonly prompt: string;
@@ -377,6 +378,68 @@ export interface AgentSaying {
 	readonly attached?: Attachment | undefined;
 }
 
+/**
+ * What the daemon says as a read opens (#211).
+ *
+ * It is the turn introducing itself rather than anything the agent said, which is why it
+ * rides its own SSE event: the rail is picking a conversation back up and needs the three
+ * facts it lost with the last response — what this turn is called, whether the process is
+ * still up, and how much of what follows is a replay rather than something happening now.
+ */
+export interface AgentAttached {
+	/** the name a stop quotes (#165), absent for a turn nobody intends to stop */
+	readonly turn?: string;
+	readonly running: boolean;
+	/** the first event id this read will carry */
+	readonly from: number;
+	/** how long the log was when the read opened: `logged - from` events are replay */
+	readonly logged: number;
+}
+
+export interface AgentReading {
+	readonly attached?: ((attached: AgentAttached) => void) | undefined;
+	readonly event: (event: AgentEvent) => void;
+	readonly end: (error?: string) => void;
+}
+
+/**
+ * Read one open response as a turn, however the response was asked for.
+ *
+ * Both doors return the same stream, so both read it the same way: the POST that starts a
+ * turn and the GET that picks one up differ in what they send and in nothing after that.
+ */
+async function readTurn(open: Promise<Response>, on: AgentReading, disposed: () => boolean): Promise<void> {
+	try {
+		const res = await open;
+		if (!res.ok || res.body === null) {
+			if (!disposed()) on.end(res.body === null ? "the turn stream never opened" : await res.text());
+			return;
+		}
+		// `disposed` gates the events too, not only the end: letting go of a read can leave
+		// a decoded batch in flight, and it must not land in the turn that replaced it
+		await drainSse(res.body, {
+			attached: (data) => {
+				if (!disposed()) on.attached?.(data as AgentAttached);
+			},
+			agent: (data) => {
+				if (!disposed()) on.event(data as AgentEvent);
+			},
+		});
+		if (!disposed()) on.end();
+	} catch (error) {
+		/*
+		 * The reason, rather than silence (#211).
+		 *
+		 * An aborted read is the caller letting go and never reaches here — `disposed` is
+		 * set before the abort. Everything else is the transport dying, and it used to be
+		 * reported as a clean end: the rail drew *the turn stream ended* over a dropped
+		 * socket, a sleeping laptop and a daemon that had gone, with no way to tell them
+		 * apart. What the browser said is worth more than that, however terse.
+		 */
+		if (!disposed()) on.end(error instanceof Error ? error.message : String(error));
+	}
+}
+
 export function streamAgentTurn(
 	project: string,
 	said: {
@@ -387,47 +450,60 @@ export function streamAgentTurn(
 		/** one message, or the several a queue fired as one turn (#170) */
 		readonly saying: readonly AgentSaying[];
 	},
-	on: { readonly event: (event: AgentEvent) => void; readonly end: (error?: string) => void },
+	on: AgentReading,
 ): () => void {
 	const controller = new AbortController();
 	let disposed = false;
-	void (async () => {
-		try {
-			// `init` is spread over what the client built, so `headers` here would replace
-			// its own `content-type: application/json` and the daemon would reject the body
-			const res = await client.api.p[":project"].agent.turn.$post(
-				{
-					param: { project },
-					json: {
-						thread: said.thread,
-						turn: said.turn,
-						said: said.saying.map((one) => ({
-							prompt: one.prompt,
-							...(one.selection === undefined ? {} : { selection: [...one.selection] }),
-							...(one.attached === undefined ? {} : { attachment: one.attached }),
-						})),
-					},
+	// `init` is spread over what the client built, so `headers` here would replace its own
+	// `content-type: application/json` and the daemon would reject the body
+	void readTurn(
+		client.api.p[":project"].agent.turn.$post(
+			{
+				param: { project },
+				json: {
+					thread: said.thread,
+					turn: said.turn,
+					said: said.saying.map((one) => ({
+						prompt: one.prompt,
+						...(one.selection === undefined ? {} : { selection: [...one.selection] }),
+						...(one.attached === undefined ? {} : { attachment: one.attached }),
+					})),
 				},
-				{ init: { signal: controller.signal } },
-			);
-			if (!res.ok || res.body === null) {
-				on.end(res.body === null ? "the turn stream never opened" : await res.text());
-				return;
-			}
-			// `disposed` gates the events too, not only the end: abandoning a turn can leave
-			// a decoded batch in flight, and it must not land in the turn that replaced it
-			await drainSse(res.body, {
-				agent: (data) => {
-					if (!disposed) on.event(data as AgentEvent);
-				},
-			});
-			if (!disposed) on.end();
-		} catch {
-			// an aborted read is the caller letting go; anything else has already been
-			// reported down the stream as a `closed` event
-			if (!disposed) on.end();
-		}
-	})();
+			},
+			{ init: { signal: controller.signal } },
+		),
+		on,
+		() => disposed,
+	);
+	return () => {
+		disposed = true;
+		controller.abort();
+	};
+}
+
+/**
+ * The turn this conversation already has, picked up where it was left (#211).
+ *
+ * The door a returning rail knocks on. A turn outlives the request that started it, so a
+ * refresh loses the response and nothing else: this asks the daemon for the turn running
+ * in a thread and reads it from `from` — zero for a fresh page, which replays the whole
+ * log and rebuilds exactly what was on screen.
+ *
+ * A 404 is the ordinary answer and not a failure: it means nothing is being held for this
+ * conversation, which is every thread that is not mid-turn. The picture on disk is the
+ * whole of what the rail can draw for one of those, and it already has it.
+ */
+export function attachAgentTurn(project: string, thread: string, from: number, on: AgentReading): () => void {
+	const controller = new AbortController();
+	let disposed = false;
+	void readTurn(
+		client.api.p[":project"].agent.turn[":thread"].$get(
+			{ param: { project, thread }, query: { from: String(from) } },
+			{ init: { signal: controller.signal } },
+		),
+		on,
+		() => disposed,
+	);
 	return () => {
 		disposed = true;
 		controller.abort();
@@ -487,7 +563,7 @@ export async function putAgentThread(project: string, thread: string, picture: T
 	try {
 		await client.api.p[":project"].agent.threads[":thread"].$put({
 			param: { project, thread },
-			json: { ...picture, entries: [...picture.entries] },
+			json: { ...picture, entries: [...picture.entries], queued: [...picture.queued] },
 		});
 	} catch {
 		// a write that never landed costs what the next one will land anyway: the picture is

--- a/src/ui/canvas/agent-queue.ts
+++ b/src/ui/canvas/agent-queue.ts
@@ -27,6 +27,23 @@ export interface AgentQueued extends AgentWords {
 }
 
 /**
+ * The queue as it comes back off disk (#211).
+ *
+ * The floor under a file a person can open in an editor, and the same one `drawableEntries`
+ * is: spool's store keeps the queue opaque because the vocabulary is up here, so this is
+ * where the shape is checked rather than down there. A row missing the two fields that
+ * make it a message — words to send and an id to take it back by — is dropped, because
+ * both of its buttons would lie.
+ */
+export function drawableQueue(queued: readonly unknown[]): AgentQueued[] {
+	return queued.filter((one): one is AgentQueued => {
+		if (typeof one !== "object" || one === null) return false;
+		const message = one as { id?: unknown; text?: unknown };
+		return typeof message.id === "string" && typeof message.text === "string" && message.text !== "";
+	});
+}
+
+/**
  * Messages that left the queue un-fired, waiting for the box to take them back.
  *
  * A signal rather than a value, which is why the count is here: whoever holds the

--- a/src/ui/canvas/agent-rail.test.ts
+++ b/src/ui/canvas/agent-rail.test.ts
@@ -2543,10 +2543,13 @@ function storedThread({
 				settled: true,
 			},
 		],
+		kept: 3,
 		plan: null,
+		queued: [],
 		stopped: false,
 		closed: false,
 		continuable: true,
+		live: false,
 		...over,
 	};
 }
@@ -3123,7 +3126,7 @@ describe("closing a thread", () => {
 	});
 
 	/** a tab nobody can reach must not go on holding a process the hands cannot see */
-	it("stops the stream the tab was holding", async () => {
+	it("stops the turn the tab was holding, and not only the read of it", async () => {
 		const canvas = mount();
 		await canvas.render();
 		await send(canvas.host, "three takes on the cart");
@@ -3136,6 +3139,9 @@ describe("closing a thread", () => {
 		await settle();
 
 		expect(canvas.turn.streams[0]?.aborted()).toBe(true);
+		// and the process with it: a turn outlives the read of it now (#211), so dropping the
+		// read is no longer what stops one — the stop has to be asked for
+		expect(canvas.turn.stops).toHaveLength(1);
 	});
 
 	it("leaves a fresh thread behind when the last one is closed", async () => {

--- a/src/ui/canvas/agent-stream.test.ts
+++ b/src/ui/canvas/agent-stream.test.ts
@@ -3,8 +3,9 @@
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it, onTestFinished, vi } from "vitest";
-import type { AgentEvent } from "../api";
+import type { AgentEvent, ServedThread } from "../api";
 import { type AgentDeck, type AgentTurn, useAgentThreads } from "./agent-stream";
+import { fullyShown } from "./agent-transcript";
 
 /**
  * The hook that owns every thread's turn (#192, #200), on its own rather than under the
@@ -16,19 +17,21 @@ import { type AgentDeck, type AgentTurn, useAgentThreads } from "./agent-stream"
  * Here nothing else renders, so the tick is the only thing that can.
  */
 
-function mount() {
+function mount(stored: readonly ServedThread[] = []) {
 	const seen: AgentDeck[] = [];
 	let open = false;
 	const encoder = new TextEncoder();
 	let ctrl: ReadableStreamDefaultController<Uint8Array> | undefined;
+	const asked: string[] = [];
 
 	vi.stubGlobal(
 		"fetch",
 		vi.fn(async (input: RequestInfo | URL) => {
 			const url = new URL(input instanceof Request ? input.url : String(input), window.location.href);
-			// a project with nothing stored, which is what every case here is about: the
+			asked.push(url.pathname + url.search);
+			// a project with nothing stored, which is what most cases here are about: the
 			// picture coming back off disk is `agent-rail.test.ts`'s
-			if (url.pathname.endsWith("/agent/threads")) return Response.json({ threads: [] });
+			if (url.pathname.endsWith("/agent/threads")) return Response.json({ threads: stored });
 			if (url.pathname.includes("/agent/threads/")) return new Response(null, { status: 204 });
 			const stream = new ReadableStream<Uint8Array>({
 				start: (controller) => {
@@ -57,7 +60,11 @@ function mount() {
 
 	return {
 		latest: () => (seen[seen.length - 1] as AgentDeck).turn as AgentTurn,
+		asked,
 		push: (event: AgentEvent) => ctrl?.enqueue(encoder.encode(`event: agent\ndata: ${JSON.stringify(event)}\n\n`)),
+		/** the line a turn opens with, which is the daemon saying what is being read (#211) */
+		attached: (info: { turn?: string; running: boolean; from: number; logged: number }) =>
+			ctrl?.enqueue(encoder.encode(`event: attached\ndata: ${JSON.stringify(info)}\n\n`)),
 		close: () => {
 			open = false;
 			ctrl?.close();
@@ -168,5 +175,104 @@ describe("the turn a thread is running", () => {
 
 		expect(canvas.latest().phase).toBe("settled");
 		expect(canvas.latest().entries.at(-1)).toMatchObject({ kind: "note", text: "the turn stream ended" });
+	});
+});
+
+/**
+ * A page that came back to a turn that never stopped (#211).
+ *
+ * The turn outlives the request that started it, so a refresh loses the response and
+ * nothing else. What the rail has to do with that is keep the conversation it stored,
+ * refold the turn off the log the daemon replays, and never draw the two over each other.
+ */
+describe("a turn picked back up", () => {
+	const THREAD = "1f0e2d3c-4b5a-4697-8899-aabbccddeeff";
+
+	/** the picture a turn in flight wrote down: the conversation, and the turn so far */
+	const midTurn = (over: Partial<ServedThread> = {}): ServedThread => ({
+		id: THREAD,
+		ask: "make the header tighter",
+		life: "running",
+		at: 1_700_000_000_000,
+		entries: [
+			{ key: "u0", kind: "user", text: "make the header tighter", context: null, attached: null },
+			{ key: "say:1:0", kind: "prose", full: "Reading the header.", landed: [], settled: true },
+		],
+		// the human's words are the conversation's; the prose under them is the turn's, and
+		// the replay is what draws that
+		kept: 1,
+		plan: null,
+		queued: [],
+		stopped: false,
+		closed: false,
+		continuable: true,
+		live: true,
+		...over,
+	});
+
+	it("attaches to the turn the daemon is still holding rather than drawing it cut", async () => {
+		const canvas = mount([midTurn()]);
+		await canvas.render();
+		await settle(120);
+
+		// it went and asked for the turn in that thread, rather than starting one
+		expect(canvas.asked.some((path) => path.includes(`/agent/turn/${THREAD}`))).toBe(true);
+
+		canvas.attached({ turn: "1700000000000-1", running: true, from: 0, logged: 1 });
+		canvas.push({ kind: "say", block: 0, text: "Reading the header.", parent: null });
+		await settle(200);
+
+		const turn = canvas.latest();
+		expect(turn.phase).toBe("playing");
+		// the human's words once, off the stored picture, and the turn's prose once, off the
+		// replay — the boundary is what keeps the second from being drawn twice
+		expect(turn.entries.filter((entry) => entry.kind === "user")).toHaveLength(1);
+		expect(turn.entries.filter((entry) => entry.kind === "prose")).toEqual([
+			{ key: "say:0:0", kind: "prose", full: "Reading the header.", landed: expect.anything(), settled: false },
+		]);
+		// and a replay is not an arrival: it is drawn whole rather than typed out from the
+		// beginning, the way a picture off disk is
+		expect(fullyShown(turn.entries.find((entry) => entry.kind === "prose") as never, turn.elapsed)).toBe(true);
+	});
+
+	it("carries on live from where the replay left off", async () => {
+		const canvas = mount([midTurn()]);
+		await canvas.render();
+		await settle(120);
+
+		canvas.attached({ turn: "1700000000000-1", running: true, from: 0, logged: 1 });
+		canvas.push({ kind: "say", block: 0, text: "Reading the header.", parent: null });
+		await settle(120);
+		canvas.push(ended);
+		canvas.push(closed);
+		canvas.close();
+		await settle(400);
+
+		// it ends the way any turn ends, on the daemon's own word for it — no invented
+		// `stopped`, and no second copy of anything
+		expect(canvas.latest().phase).toBe("settled");
+		expect(canvas.latest().entries.filter((entry) => entry.kind === "note")).toEqual([]);
+	});
+
+	it("takes back the messages it was holding when the page went away", async () => {
+		const canvas = mount([
+			midTurn({ queued: [{ id: "held-1", text: "and the footer", context: null, attached: null }] }),
+		]);
+		await canvas.render();
+		await settle(120);
+
+		// spool holds the queue, and a browser is the one place a thing can be lost by a
+		// keystroke: they come back with the picture rather than going with the page
+		expect(canvas.latest().queued.map((one) => one.text)).toEqual(["and the footer"]);
+	});
+
+	it("draws a thread the daemon is no longer holding as the cut it was", async () => {
+		const canvas = mount([midTurn({ live: false, stopped: true })]);
+		await canvas.render();
+		await settle(120);
+
+		expect(canvas.asked.some((path) => path.includes(`/agent/turn/${THREAD}`))).toBe(false);
+		expect(canvas.latest().phase).toBe("idle");
+		expect(canvas.latest().entries.at(-1)).toMatchObject({ kind: "note", text: "stopped" });
 	});
 });

--- a/src/ui/canvas/agent-stream.ts
+++ b/src/ui/canvas/agent-stream.ts
@@ -3,7 +3,10 @@ import type { AgentReply } from "../../daemon/agent-control";
 import type { AgentLimit } from "../../daemon/agent-events";
 import type { ServedThread } from "../../daemon/agent-threads";
 import {
+	type AgentAttached,
+	type AgentReading,
 	answerAgentTurn,
+	attachAgentTurn,
 	closeAgentThread,
 	fetchAgentLogin,
 	fetchAgentThreads,
@@ -12,7 +15,7 @@ import {
 	streamAgentTurn,
 } from "../api";
 import { type LoginDeck, STILL_OUT, signedInAs } from "./agent-preflight";
-import type { AgentHandback, AgentQueued } from "./agent-queue";
+import { type AgentHandback, type AgentQueued, drawableQueue } from "./agent-queue";
 import {
 	askOf,
 	bounced,
@@ -75,6 +78,18 @@ const TICK_MS = 100;
  * send, the settle, a look — writes immediately regardless.
  */
 const SAVE_MS = 2000;
+
+/**
+ * How far in the past a picked-up turn's clock is started (#211).
+ *
+ * Everything replayed is stamped at zero, so this is what makes all of it due at once: a
+ * turn arriving whole is drawn whole rather than typed out from the beginning, which is
+ * the rule a picture off disk has always been under. Anything the pace could still be
+ * owed is bounded by the turn's own length, so a day is not a number to tune — it is far
+ * past every schedule a turn can write, and what arrives after the replay paces normally
+ * from wherever the clock then stands.
+ */
+const REPLAYED_MS = 86_400_000;
 
 /**
  * What the turn is doing, and the one member that is about the person (#145).
@@ -317,13 +332,24 @@ function restored(stored: ServedThread): Live {
 	// nothing off disk is being paced: the clock its schedule was written against ended
 	// with the daemon that held it
 	const entries = unpaced(drawableEntries(stored.entries));
+	/*
+	 * A turn this daemon is still holding is not a cut and not a drawing: it is a stream to
+	 * pick back up (#211). What is kept of the picture is everything above the boundary the
+	 * rail wrote with it — the conversation, and the words that started the turn — and the
+	 * turn itself is refolded from the log rather than taken off disk, so it is never drawn
+	 * twice.
+	 */
+	const before = stored.live ? entries.slice(0, stored.kept) : stored.stopped ? cutPicture(entries) : entries;
 	return born(stored.id, {
-		before: stored.stopped ? cutPicture(entries) : entries,
+		before,
 		heldPlan: (stored.plan ?? null) as AgentPlan | null,
 		restored: true,
 		continuable: stored.continuable,
 		unread: stored.life === "unread",
 		at: stored.at,
+		// the words spool was holding when the page went away, which are spool's to hold
+		// across one too (#170, #211)
+		holding: drawableQueue(stored.queued),
 	});
 }
 
@@ -351,6 +377,28 @@ function entriesOf(thread: Live, seen: { entries: readonly AgentEntry[] }): read
 				? seen.entries
 				: [...thread.before, ...seen.entries];
 	return thread.after.length === 0 ? drawn : [...drawn, ...thread.after];
+}
+
+/**
+ * How much of the stored picture is not drawn from the live turn's events (#211).
+ *
+ * The boundary a client picking this turn back up has to cut at. Everything above it came
+ * off earlier turns, out of the log between them, or out of what the human said to start
+ * this one — and none of that is in the event log, so none of it can be refolded. What
+ * sits below it is exactly `transcriptOf`'s fold, which a replay rebuilds whole.
+ *
+ * The words the turn was started with are above the line rather than below it because the
+ * daemon's log does not carry them: the prompt went down stdin and the row was drawn from
+ * what the composer captured. A turn started by a held prompt drew none of its own (#201),
+ * which is what `carried` says and why the count is the transcript's rather than a
+ * constant.
+ *
+ * Everything, for a thread with no turn running: nothing will be replayed over it, and a
+ * picture that claimed a boundary it had no turn for would cut itself short.
+ */
+function keptOf(thread: Live, shown: { entries: readonly AgentEntry[] }): number {
+	if (!thread.streaming) return thread.before.length + shown.entries.length + thread.after.length;
+	return thread.before.length + (thread.carried ? 0 : thread.said.length);
 }
 
 /**
@@ -437,7 +485,12 @@ export function useAgentThreads(project: string): AgentDeck {
 				// nothing on disk is being paced: what a reader will see is drawn whole, so the
 				// schedule goes rather than sitting there meaning nothing
 				entries: unpaced(entries),
+				// where the turn in flight begins, so a reader that can pick that turn up keeps
+				// the conversation and refolds the rest off the log rather than drawing it twice
+				// (#211). Everything, once nothing is running: `keptOf` is the whole rule
+				kept: keptOf(thread, shown),
 				plan: planOf(thread, shown),
+				queued: thread.holding,
 			});
 		},
 		[project],
@@ -459,9 +512,18 @@ export function useAgentThreads(project: string): AgentDeck {
 		[save],
 	);
 
-	const send = useCallback(
-		(thread: Live, saying: readonly AgentWords[], carried = false) => {
-			if (saying.length === 0) return;
+	/**
+	 * One turn read into a thread, whether this rail started it or found it (#191, #211).
+	 *
+	 * Both ways in are the same turn seen from different distances, so they are one
+	 * function: a send says something and reads the answer from the first event, and an
+	 * attach says nothing and reads a turn already in progress from wherever it can. What
+	 * differs between them is three lines at the top and which door is opened at the bottom.
+	 */
+	const run = useCallback(
+		(thread: Live, opening: { saying: readonly AgentWords[]; carried: boolean } | { attach: true }) => {
+			const attaching = "attach" in opening;
+			if (!attaching && opening.saying.length === 0) return;
 			thread.abandon?.();
 			// the conversation keeps what it has already drawn: a turn replaces the events it
 			// is folded from, never the turns before it
@@ -473,23 +535,41 @@ export function useAgentThreads(project: string): AgentDeck {
 				thread.before = [...thread.before, ...thread.after];
 				thread.after = [];
 			}
-			thread.carried = carried;
+			/*
+			 * A turn being picked up draws no words of its own, for #201's reason and a second
+			 * one: the human's sentence is already in the picture this thread came back with —
+			 * it is the last thing above the boundary the daemon replays from — and the log the
+			 * replay rebuilds starts after it.
+			 */
+			thread.carried = attaching || opening.carried;
 			thread.events = [];
 			thread.started = Date.now();
 			thread.parked = { total: 0, since: null };
 			thread.waitingOn = new Map();
-			thread.said = saying;
+			thread.said = attaching ? [] : opening.saying;
 			thread.streaming = true;
 			thread.run += 1;
-			thread.starts += 1;
 			thread.ms = 0;
 			thread.drained = false;
-			thread.unread = false;
-			thread.at = Date.now();
 			thread.restored = false;
-			// a name of its own, because a stop has no request to quote: it names the turn the
-			// hands are looking at rather than whatever this project is running
-			thread.named = `${Date.now()}-${thread.starts}`;
+			if (!attaching) {
+				thread.starts += 1;
+				thread.unread = false;
+				thread.at = Date.now();
+				// a name of its own, because a stop has no request to quote: it names the turn the
+				// hands are looking at rather than whatever this project is running. A turn being
+				// picked up already has one, and the daemon says it on the way in
+				thread.named = `${Date.now()}-${thread.starts}`;
+			}
+			/**
+			 * How many of the events still to arrive already happened (#211).
+			 *
+			 * A replay is not an arrival. Everything before this rail attached is stamped at zero
+			 * against a clock started long enough ago that all of it is due, which draws it whole
+			 * — the same rule a picture off disk is under, and for the same reason: neither of
+			 * them is happening now. What arrives after the replay is paced as it always was.
+			 */
+			let replaying = 0;
 			const clock = () =>
 				Date.now() -
 				thread.started -
@@ -512,61 +592,77 @@ export function useAgentThreads(project: string): AgentDeck {
 				else if (thread.parked.since !== null) {
 					thread.parked = { total: thread.parked.total + (Date.now() - thread.parked.since), since: null };
 				}
-				thread.events.push({ at: clock(), event });
+				thread.events.push({ at: replaying > 0 ? 0 : clock(), event });
+				if (replaying > 0) replaying -= 1;
 			};
-			thread.abandon = streamAgentTurn(
-				project,
-				{
-					thread: thread.id,
-					turn: thread.named,
-					saying: saying.map((words) => ({
-						prompt: words.text,
-						selection: words.selection,
-						attached: words.attached ?? undefined,
-					})),
-				},
-				{
-					event: push,
+			/** what the daemon says as the read opens, which is the turn introducing itself */
+			const attached = (info: AgentAttached) => {
+				if (info.turn !== undefined) thread.named = info.turn;
+				replaying = Math.max(0, info.logged - info.from);
+				if (replaying > 0) thread.started = Date.now() - REPLAYED_MS;
+			};
+			const reading: AgentReading = {
+				attached,
+				event: push,
+				/*
+				 * The stream is the turn's whole life, so its end has to leave the log saying
+				 * why. The daemon ends every turn with a `closed` event; a stream that stops
+				 * without one stopped on this side, and the union already has the member for a
+				 * process that is gone.
+				 */
+				end: (error) => {
+					if (error !== undefined) push({ kind: "closed", code: null, message: error, parent: null });
+					else if (thread.events.at(-1)?.event.kind !== "closed") {
+						push({ kind: "closed", code: null, message: "the turn stream ended", parent: null });
+					}
+					thread.streaming = false;
+					thread.at = Date.now();
+					// it landed while nobody was looking at it, and a look is the only thing that
+					// clears that (#161) — so the flag is set here and read nowhere else
+					if (thread.id !== openRef.current) thread.unread = true;
+					// the conversation continues under the same id from here, whatever the disk
+					// still says about the session that started it
+					thread.continuable = true;
+					save(thread);
 					/*
-					 * The stream is the turn's whole life, so its end has to leave the log saying
-					 * why. The daemon ends every turn with a `closed` event; a stream that stops
-					 * without one stopped on this side, and the union already has the member for a
-					 * process that is gone.
+					 * The queue fires the moment the turn is no longer running (#170).
+					 *
+					 * Every message at once, in order, as one turn: the binary reads all of them as
+					 * the one thing it was asked, so this is a send rather than a run of sends. A
+					 * stop never reaches here, because a stop empties the list before the stream can
+					 * close — which is the invariant, not a race that happens to fall the right way.
 					 */
-					end: (error) => {
-						if (error !== undefined) push({ kind: "closed", code: null, message: error, parent: null });
-						else if (thread.events.at(-1)?.event.kind !== "closed") {
-							push({ kind: "closed", code: null, message: "the turn stream ended", parent: null });
-						}
-						thread.streaming = false;
-						thread.at = Date.now();
-						// it landed while nobody was looking at it, and a look is the only thing that
-						// clears that (#161) — so the flag is set here and read nowhere else
-						if (thread.id !== openRef.current) thread.unread = true;
-						// the conversation continues under the same id from here, whatever the disk
-						// still says about the session that started it
-						thread.continuable = true;
-						save(thread);
-						/*
-						 * The queue fires the moment the turn is no longer running (#170).
-						 *
-						 * Every message at once, in order, as one turn: the binary reads all of them as
-						 * the one thing it was asked, so this is a send rather than a run of sends. A
-						 * stop never reaches here, because a stop empties the list before the stream can
-						 * close — which is the invariant, not a race that happens to fall the right way.
-						 */
-						const firing = thread.holding;
-						if (firing.length > 0) {
-							thread.holding = [];
-							send(thread, firing);
-						}
-						redraw();
-					},
+					const firing = thread.holding;
+					if (firing.length > 0) {
+						thread.holding = [];
+						run(thread, { saying: firing, carried: false });
+					}
+					redraw();
 				},
-			);
+			};
+			thread.abandon = attaching
+				? attachAgentTurn(project, thread.id, 0, reading)
+				: streamAgentTurn(
+						project,
+						{
+							thread: thread.id,
+							turn: thread.named,
+							saying: opening.saying.map((words) => ({
+								prompt: words.text,
+								selection: words.selection,
+								attached: words.attached ?? undefined,
+							})),
+						},
+						reading,
+					);
 			redraw();
 		},
 		[project, save, redraw],
+	);
+
+	const send = useCallback(
+		(thread: Live, saying: readonly AgentWords[], carried = false) => run(thread, { saying, carried }),
+		[run],
 	);
 
 	/*
@@ -583,7 +679,18 @@ export function useAgentThreads(project: string): AgentDeck {
 			if (gone) return;
 			for (const one of stored) {
 				if (threads.current.has(one.id)) continue;
-				threads.current.set(one.id, restored(one));
+				const thread = restored(one);
+				threads.current.set(one.id, thread);
+				/*
+				 * A turn still running here is picked up rather than drawn (#211).
+				 *
+				 * This is the whole of what a refresh costs now: the daemon held the turn, the log
+				 * is replayed into a fold that rebuilds what was on screen, and the rest arrives
+				 * as it always would have. It happens for every live thread and not only the one
+				 * the column opens on, because they were all still working while the page was
+				 * away — which is the same promise #192 made about looking at another thread.
+				 */
+				if (one.live) run(thread, { attach: true });
 			}
 			// the row opens on something either way, so this only ever runs before it has:
 			// a project with nothing stored gets one fresh thread, which is what the rail
@@ -603,7 +710,7 @@ export function useAgentThreads(project: string): AgentDeck {
 		return () => {
 			gone = true;
 		};
-	}, [project, start, read, redraw]);
+	}, [project, start, read, redraw, run]);
 
 	/*
 	 * One clock for every thread, and the one thing that stops each of them.
@@ -652,8 +759,14 @@ export function useAgentThreads(project: string): AgentDeck {
 		return () => clearInterval(timer);
 	}, [still, save, redraw]);
 
-	// every thread belongs to the canvas that opened it: navigating away ends them all,
-	// and the daemon takes each process with its request
+	/*
+	 * Every read belongs to the canvas that opened it: navigating away drops all of them,
+	 * and takes no turn with it (#211).
+	 *
+	 * Which is the point. A refresh, a lid, a tab closed by accident — the daemon holds
+	 * what was running, and the next page attaches to it and carries on. The one exit that
+	 * still stops a turn is a hand: the stop button, or closing the thread it belongs to.
+	 */
 	useEffect(() => {
 		const held = threads.current;
 		return () => {
@@ -750,9 +863,15 @@ export function useAgentThreads(project: string): AgentDeck {
 			 * Closing a thread is a tidy rather than a delete (#136).
 			 *
 			 * It leaves the column, and neither the agent's own session nor spool's stored
-			 * picture goes with it. What does stop is the stream, because a tab nobody can
+			 * picture goes with it. What does stop is the turn, because a tab nobody can
 			 * reach must not go on holding a process the hands cannot see.
+			 *
+			 * Both halves are said out loud now that a turn outlives the read of it (#211):
+			 * letting go of the stream used to take the process with it, and letting go is now
+			 * only letting go. So the turn is stopped the way the stop button stops one — a
+			 * request the binary survives and ends itself on — and then the read is dropped.
 			 */
+			if (thread.streaming) void interruptAgentTurn(project, thread.named);
 			thread.abandon?.();
 			threads.current.delete(id);
 			void closeAgentThread(project, id);


### PR DESCRIPTION
Closes #211.

A refresh no longer kills the agent.

## What was wrong

The turn owned the process for exactly as long as the HTTP request lived — `stream.onAbort(() => turn.abandon())`, plus an `abandon()` in the SSE handler's `finally`. Any disconnect SIGTERMed the binary mid-edit.

The queue looked broken for the same reason. It fires from inside the dying stream's own `end` callback, and a transport failure is what calls that callback, so the held message went out over the transport that had just failed. And `catch { if (!disposed) on.end() }` threw the error away, so every cause rendered as the same six words.

## What changed

**`src/daemon/agent-live.ts` (new).** A held turn drains itself into an event log whether or not anybody is reading, and hands out views of that log. A viewer arrives, reads from wherever it left off, follows what comes next, and leaves without the process noticing. Plus the registry: one turn per conversation, keyed by thread.

**The stream became a view.** `POST /agent/turn` starts a turn and attaches; `GET /agent/turn/:thread?from=N` attaches to one already running. `onAbort` closes the view instead of abandoning the turn. Both doors open by saying what is being read — the turn's name, whether the process is up, and how much of what follows is replay.

**The rail refolds from the replay.** `restored()` keeps the picture above the boundary the rail wrote with it (`kept`) and rebuilds the turn off the log, so nothing is drawn twice. Replayed events are stamped so the turn arrives whole rather than typing itself out from the beginning, which is the rule a picture off disk was already under.

**A second turn in a running thread is refused** with a 409 rather than putting two agents in the same repo.

**An ended turn is kept for five minutes**, so a client that was away reads the real ending rather than the rail inventing a `stopped`.

**Closing a thread now stops its turn explicitly** — an interrupt, the way the stop button does it. Letting go of a read is no longer what stops a process, so that had to be said out loud.

**Smaller, same ticket:** the queue is stored with the thread, and a transport error is reported instead of swallowed.

## Tests

- `agent-live.test.ts` — the drain with no reader, a viewer leaving without the turn going, resuming from an offset, two viewers at once, the grace window, the daemon's blunt exit.
- `agent-turn.test.ts` — the reader hangs up and the process lives; the next read gets the whole turn; the 409; the 404 when nothing is held; `live` on the threads listing.
- `agent-stream.test.ts` — a restored live thread attaches rather than drawing a cut, the picture is not doubled, the queue comes back, and a thread the daemon is not holding still draws as the cut it was.

`pnpm test`, `pnpm typecheck` and `pnpm check` are clean. Not yet driven in a real browser against a live daemon.