### PR TITLE
fix: only offer an update to an install that can take one

### DIFF
--- a/.changeset/no-update-offer-without-a-door.md
+++ b/.changeset/no-update-offer-without-a-door.md
@@ -1,0 +1,5 @@
+---
+"spool.page": patch
+---
+
+Spool only offers an update when it can actually install one. Running from a git checkout, or any install no package manager owns, no longer shows the update toast and no longer asks npm daily whether a newer release exists. The Update button there could only ever fail, because that kind of install updates with `git pull`.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -492,7 +492,7 @@ describe("spool cli", { timeout: 30_000 }, () => {
 		expect(result.stderr).toContain("git");
 	});
 
-	it("status mentions a cached newer release without phoning home (#30)", () => {
+	it("status keeps a cached release to itself when this install cannot take it (#30)", () => {
 		const home = makeTempDir();
 		mkdirSync(join(home, ".spool"), { recursive: true });
 		writeFileSync(
@@ -500,11 +500,14 @@ describe("spool cli", { timeout: 30_000 }, () => {
 			JSON.stringify({ latest: "99.0.0", checkedAt: new Date().toISOString() }),
 		);
 
+		// the cli under test is this checkout, whose only upgrade is git: no
+		// checkout daemon writes that cache any more, so one found there is stale
+		// and "run `spool upgrade`" is an instruction that refuses itself
 		const result = spool(["status"], home);
 
 		expect(result.status).toBe(1); // daemon still not running
-		expect(result.stdout).toContain("v99.0.0 available");
-		expect(result.stdout).toContain("spool upgrade");
+		expect(result.stdout).not.toContain("99.0.0");
+		expect(result.stdout).not.toContain("spool upgrade");
 	});
 
 	it("fails cleanly on an unknown command", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ import { isSafeName } from "./page-path";
 import { removeProject } from "./remove";
 import { resolveProjectRoot } from "./resolve";
 import { skillText } from "./skill";
-import { runUpgrade } from "./upgrade";
+import { runUpgrade, selfUpgradeable } from "./upgrade";
 import { mintPlayerUrl, mintRawUrl, readFlows, readSelection, resolveRegisteredProject } from "./verbs";
 import { logsFrame, shotFrame } from "./verify";
 
@@ -269,7 +269,9 @@ program
 					port: config.port,
 					uiDir,
 					development,
-					updateCheck: config.updateCheck,
+					// #30: an install no package manager owns cannot take an upgrade,
+					// so it is never offered one — the checkout included
+					updateCheck: config.updateCheck && selfUpgradeable(),
 				});
 			} catch (error) {
 				if (error instanceof PortBusyError) {
@@ -414,8 +416,10 @@ program
 	.description("report whether the daemon is running")
 	.action(async () => {
 		const status = await statusDaemon(spoolDir);
-		// the daemon's cached daily check (#30) — status itself never phones home
-		const cache = readUpdateCache(spoolDir);
+		const upgradeable = selfUpgradeable();
+		// the daemon's cached daily check (#30) — status itself never phones home,
+		// and stays quiet where no daemon writes that cache any more
+		const cache = upgradeable ? readUpdateCache(spoolDir) : undefined;
 		const available =
 			cache !== undefined && isNewer(cache.latest, pkg.version)
 				? ` — v${cache.latest} available, run \`spool upgrade\``
@@ -425,8 +429,10 @@ program
 			process.exitCode = 1;
 			return;
 		}
-		const skew =
-			status.version === pkg.version ? "" : ` — cli is v${pkg.version}, \`spool upgrade\` brings them in step`;
+		// a skew is real news either way, but the way out of it differs: a managed
+		// install reinstalls, a checkout restarts onto the code already on disk
+		const fix = upgradeable ? "`spool upgrade` brings them in step" : "restart it to catch it up";
+		const skew = status.version === pkg.version ? "" : ` — cli is v${pkg.version}, ${fix}`;
 		process.stdout.write(
 			`spool daemon running at ${status.url} (pid ${status.pid}, v${status.version})${skew}${available}\n`,
 		);

--- a/src/upgrade.test.ts
+++ b/src/upgrade.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { DaemonStatus } from "./daemon/lifecycle";
 import { SpoolError } from "./errors";
 import { makeTempDir } from "./test-helpers";
-import { planUpgrade, requestUpgrade, runUpgrade, type UpgradeIo } from "./upgrade";
+import { planUpgrade, requestUpgrade, runUpgrade, selfUpgradeable, type UpgradeIo } from "./upgrade";
 
 describe("planUpgrade", () => {
 	it("classifies an npm-global install and resolves npm beside node", () => {
@@ -369,6 +369,49 @@ describe("runUpgrade", () => {
 		await runUpgrade(makeTempDir(), "0.1.0", io);
 
 		expect(lines.some((line) => line.includes("npm"))).toBe(true);
+	});
+});
+
+describe("selfUpgradeable", () => {
+	const globalCli = "/opt/homebrew/lib/node_modules/spool.page/dist/cli.js";
+
+	it("is true for an install a package manager owns", () => {
+		expect(
+			selfUpgradeable({
+				cliPath: globalCli,
+				resolveReal: (path) => path,
+				execPath: "/opt/homebrew/bin/node",
+				isFile: (p) => p === "/opt/homebrew/bin/npm",
+			}),
+		).toBe(true);
+	});
+
+	it("is false for the checkout, whose only upgrade is git", () => {
+		expect(selfUpgradeable({ cliPath: "/Users/liam/projects/spool/src/cli.ts", resolveReal: (path) => path })).toBe(
+			false,
+		);
+	});
+
+	it("is false when the manager that owns the install cannot be found", () => {
+		expect(
+			selfUpgradeable({
+				cliPath: globalCli,
+				resolveReal: (path) => path,
+				execPath: "/opt/homebrew/bin/node",
+				isFile: () => false,
+			}),
+		).toBe(false);
+	});
+
+	it("is false when the running cli path cannot be resolved", () => {
+		expect(
+			selfUpgradeable({
+				cliPath: globalCli,
+				resolveReal: () => {
+					throw new Error("ENOENT");
+				},
+			}),
+		).toBe(false);
 	});
 });
 

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -300,6 +300,24 @@ export async function runUpgrade(
 }
 
 /**
+ * Whether this install can take an upgrade at all — the gate on offering one.
+ * Only a package manager's install has a door: a checkout upgrades by `git
+ * pull`, and any other unmanaged layout by hand, so `planUpgrade` refuses
+ * both. A daemon that offered one anyway would toast a button that can only
+ * fail, which is what the dogfood checkout did until this gate existed. False
+ * also silences the daily registry ask: nothing worth phoning home about.
+ */
+export function selfUpgradeable(
+	io: Pick<UpgradeIo, "cliPath" | "resolveReal" | "env" | "execPath" | "isFile"> = {},
+): boolean {
+	try {
+		return planUpgrade((io.resolveReal ?? realpathSync)(io.cliPath ?? selfCliPath()), io).ok;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * The toast door: refuse what the CLI would refuse (so the canvas hears the
  * reason immediately), otherwise spawn `spool upgrade` detached, logging
  * with the daemon. The SSE drop and the version flip tell the rest.


### PR DESCRIPTION
The update toast offered a button its own door refuses. `spool upgrade` has always
turned down an install no package manager owns ("the running spool is the development
checkout — run: git pull"), but the daemon offered the update anyway, so the dogfood
checkout toasted `Update available — v0.6.0` with an Update button that could only fail.

The rule is now: only offer an update you can actually install. `selfUpgradeable()` asks
`planUpgrade` the question it already knew the answer to, and gates three places:

- the daemon no longer starts the check at all, so no toast and no daily npm phone-home
  from a checkout
- `spool status` stops reading the cached version, since nothing refreshes it any more and
  a stale one carries a wrong instruction
- the version-skew line had the same bug: it told a checkout to run `spool upgrade`, and
  now says to restart the daemon, which is the actual fix there

The gate is "does a package manager own this install", not "is `SPOOL_DIR` set". That also
covers `npm link`, a bare clone and a hand-unpacked tarball, and it does not misfire for
someone running a real install on a custom state dir.

`updateCheck: false` in `config.json` still works as the opt-out. It cannot turn the check
back on for an install that cannot take one, which would rebuild the broken offer.

Follow-up to #30.

## Verification

Restarted the dev daemon, planted a cache claiming `v99.0.0`, and the SSE hello came back
`{"version":"0.6.0","latest":null}` with `pnpm dev status` silent. Before this it toasted.

One existing test flipped meaning: it asserted `status` mentions a cached release, which
only ever passed because the test runner is a checkout, the exact case that should stay
quiet. Four unit tests cover the predicate. Tests, `pnpm typecheck` and `pnpm check` pass.
